### PR TITLE
PR - fix(css): hero accent color inheritance to match headline

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -227,16 +227,7 @@ em {
 }
 
 .gradient-text {
-  color: #3B82F6;
-}
-@supports ((-webkit-background-clip: text) or (background-clip: text)) and (-webkit-text-fill-color: transparent) {
-  .gradient-text {
-    background: linear-gradient(135deg, #2563EB 0%, #06B6D4 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    color: transparent;
-  }
+  color: inherit;
 }
 
 .header {
@@ -987,18 +978,7 @@ textarea.form-control {
   }
 }
 .hero__headline .hero__accent {
-  color: #3B82F6;
-}
-@supports ((-webkit-background-clip: text) or (background-clip: text)) and (-webkit-text-fill-color: transparent) {
-  .hero__headline .hero__accent {
-    background: linear-gradient(135deg, #2563EB 0%, #06B6D4 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    color: transparent;
-  }
-}
-.hero__headline .hero__accent {
+  color: inherit;
   display: inline-block;
 }
 .hero__description {

--- a/github/ISSUES/fix-hero-accent-color-inheritance.md
+++ b/github/ISSUES/fix-hero-accent-color-inheritance.md
@@ -1,0 +1,51 @@
+# fix(css, sass): hero accent text color inheritance to match headline
+
+## Summary
+
+Updated hero accent text rendering to use color inheritance instead of solid blue, eliminating the blue block artifact while ensuring "Digital Future" matches the parent headline's white text color.
+
+---
+
+## Problem
+
+After removing the gradient clipping approach (which was rendering as a blue rectangle), the hero accent was displaying in solid brand blue (`#3B82F6`), creating a visual mismatch with the parent headline "Build Your" which displays in white (`#F0F6FC`).
+
+---
+
+## Solution
+
+Changed the gradient-text mixin to use `color: inherit;` instead of a hardcoded color. This ensures:
+
+1. Hero accent inherits the parent `.hero__headline` color (white)
+2. No blue block artifact
+3. Consistent visual appearance across "Build Your" and "Digital Future"
+4. Reliable cross-browser rendering without complex clipping rules
+
+---
+
+## Files Changed
+
+- `sass/abstracts/_mixins.scss` — Updated `@mixin gradient-text` to use `color: inherit;`
+- `dist/css/main.css` — Updated `.gradient-text` and `.hero__headline .hero__accent` selectors
+
+---
+
+## Acceptance Criteria
+
+- "Build Your" and "Digital Future" display in matching white text
+- No blue rectangle or solid blue text visible
+- Consistent rendering in Chrome, Firefox, and Safari
+- Local preview and Cloudflare deployment render identically
+
+---
+
+## Related
+
+- Closes issue #3 (blue block rendering in production)
+
+---
+
+## Labels
+
+- `bug`
+- `fix`

--- a/github/ISSUES/fix-hero-accent-color-inheritance.md
+++ b/github/ISSUES/fix-hero-accent-color-inheritance.md
@@ -41,7 +41,7 @@ Changed the gradient-text mixin to use `color: inherit;` instead of a hardcoded 
 
 ## Related
 
-- Closes issue #3 (blue block rendering in production)
+- Closes issue #5 (blue block rendering in production)
 
 ---
 

--- a/sass/abstracts/_mixins.scss
+++ b/sass/abstracts/_mixins.scss
@@ -75,19 +75,10 @@
 }
 
 @mixin gradient-text {
-  // Fallback: solid brand blue so text is always visible, even if
-  // background-clip: text isn't honoured by the browser / rendering path.
-  color: $flow-blue;
-
-  // Only enable transparent text when both clipping and text-fill are
-  // supported; this prevents rectangular gradient blocks in some engines.
-  @supports (((-webkit-background-clip: text) or (background-clip: text)) and (-webkit-text-fill-color: transparent)) {
-    background: $brand-gradient;
-    -webkit-background-clip: text;
-            background-clip: text;
-    -webkit-text-fill-color: transparent;
-            color: transparent;
-  }
+  // Note: background-clip: text can render as a solid rectangle instead of
+  // clipping to glyphs in some production rendering paths. For hero accents,
+  // inherit parent text color for consistent rendering.
+  color: inherit;
 }
 
 // ---------- Visually hidden ---------------------------------------------

--- a/sass/abstracts/_mixins.scss
+++ b/sass/abstracts/_mixins.scss
@@ -74,7 +74,7 @@
   padding: $space-xl;
 }
 
-@mixin gradient-text {
+@mixin inherit-text-color {
   // Note: background-clip: text can render as a solid rectangle instead of
   // clipping to glyphs in some production rendering paths. For hero accents,
   // inherit parent text color for consistent rendering.

--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -94,5 +94,5 @@ em     { font-style: italic; }
 
 // Gradient headline helper
 .gradient-text {
-  @include gradient-text;
+  @include inherit-text-color;
 }

--- a/sass/pages/_home.scss
+++ b/sass/pages/_home.scss
@@ -89,7 +89,7 @@
     }
 
     .hero__accent {
-      @include gradient-text;
+      @include inherit-text-color;
       display: inline-block;
     }
   }


### PR DESCRIPTION
fix(app); second attempt to fix cloudflare blueout

Closes #5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Cloudflare "blue block" rendering bug by replacing the gradient-text approach (which caused a solid rectangle artifact in some production rendering paths) with `color: inherit` across both the hero accent and the `.gradient-text` utility class. Both previous review concerns — misleading mixin name and mismatched issue reference — have been resolved: the mixin is now `inherit-text-color` and the issue doc consistently references #5.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are narrow, intentional, and address a confirmed production rendering bug with no new issues introduced.

All findings from the prior review round have been addressed. No new bugs, logic errors, or security concerns were found. Remaining observations (the public `.gradient-text` CSS class name still not matching the new behavior) are at most P2 style nits that don't affect correctness.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sass/abstracts/_mixins.scss | Renamed `gradient-text` mixin to `inherit-text-color` and replaced all gradient logic with `color: inherit` — addresses prior review concern about misleading name. |
| sass/base/_typography.scss | Call site updated from `@include gradient-text` to `@include inherit-text-color`; the public `.gradient-text` utility class name is unchanged. |
| sass/pages/_home.scss | `.hero__accent` call site updated to `@include inherit-text-color`; `display: inline-block` retained correctly. |
| dist/css/main.css | Compiled output correctly reflects the Sass changes — gradient/`@supports` blocks removed, both `.gradient-text` and `.hero__headline .hero__accent` now emit only `color: inherit`. |
| github/ISSUES/fix-hero-accent-color-inheritance.md | New issue-tracking document; issue reference now consistently says "Closes issue #5", aligning with the PR description (prior mismatch resolved). |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(app): address comments in PR 6 commi..."](https://github.com/bytes0211/bytestreams/commit/fe1833cf678c9c60668c9c799ad4e3d4383fb19c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29202112)</sub>

<!-- /greptile_comment -->