### PR TITLE
PR - chore(copy): update footer row copy and product links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AI agents (Oz / Warp) across branches and sessions.
 
 **Agent:** Oz (Warp)
 
-### Changes Made
+### Updates Applied
 
 #### Hero section copy (`index.html`)
 Updated the hero description from generic placeholder text to brand-aligned
@@ -42,7 +42,7 @@ New BEM modifiers to support the header brand block:
   documenting the branch changes.
 - Created GitHub issue [#1](https://github.com/Bytes0211/bytestreams/issues/1).
 
-### Files Modified
+### Files Modified (2026-04-22)
 - `index.html`
 - `privacy.html`
 - `terms.html`
@@ -51,3 +51,51 @@ New BEM modifiers to support the header brand block:
 - `README.md`
 - `AGENTS.md` *(this file)*
 - `github/ISSUES/copy-updates-header-tagline.md` *(new)*
+
+---
+
+## 2026-04-22 — `copy/footer-and-legal-pages`
+
+**Agent:** GitHub Copilot
+
+### Changes Made
+
+#### Cookie Policy page (`cookies.html`)
+Created a dedicated Cookie Policy page using copy from `docs/coookie-policy.md` and wired it into the existing legal-page shell (header, section header, footer).
+
+#### Footer information architecture (`index.html`, `privacy.html`, `terms.html`, `cookies.html`)
+Reworked footer navigation from stacked columns into a row-first site map beside the logo, matching requested reading order:
+
+- **Company -> About -> Security**
+- **Product -> DialTone.menu -> DialTone.med (comming soon) -> Features**
+- **Legal -> Privacy -> Terms -> Cookie Policy**
+
+Implemented arrow separators (`->`) between row links and kept row labels aligned on the left.
+
+#### Product link updates
+- Updated **DialTone.menu** to link to `https://dialtone.menu` across all footer instances.
+- Kept **DialTone.med** as placeholder (`#`) and updated label text to **DialTone.med (comming soon)** per request.
+
+#### Sass updates (`sass/layout/_footer.scss`, `sass/base/_typography.scss`)
+- Added footer row-map styling to support top-down labels and left-to-right links.
+- Added long-form legal content helper (`.legal-doc`) used by legal/policy pages.
+- Regenerated `dist/css/main.css`.
+
+#### Documentation and tracking
+- Updated `README.md` overview and structure sections to include:
+  - row-based footer map
+  - dedicated legal pages (`privacy.html`, `terms.html`, `cookies.html`)
+- Created issue note `github/ISSUES/copy-updates-footer-navigation.md`.
+- Created GitHub issue [#7](https://github.com/Bytes0211/bytestreams/issues/7).
+
+### Files Modified
+- `index.html`
+- `privacy.html`
+- `terms.html`
+- `cookies.html` *(new)*
+- `sass/layout/_footer.scss`
+- `sass/base/_typography.scss`
+- `dist/css/main.css` *(generated)*
+- `README.md`
+- `AGENTS.md` *(this file)*
+- `github/ISSUES/copy-updates-footer-navigation.md` *(new)*

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ and the layout in `site/*.png`:
 - **Features** — "Why Choose Us" 3×2 feature grid
 - **Contact** — Contact info + form
 - **Header** — Logo with "Smarter Workflows, Stronger Results." tagline beneath (desktop only)
-- **Footer** — Logo, tagline, and Product / Company / Legal columns
+- **Footer** — Row-based site map next to brand block:
+  - Company -> About -> Security
+  - Product -> DialTone.menu -> DialTone.med (comming soon) -> Features
+  - Legal -> Privacy -> Terms -> Cookie Policy
+- **Legal pages** — Dedicated `privacy.html`, `terms.html`, and `cookies.html`
 
 Dark-mode-first per brand guidelines (§7.1), with an alternate light palette
 already wired up via `body[data-theme="light"]`.
@@ -50,9 +54,12 @@ Then deploy `index.html`, `dist/`, `js/`, and `assets/` to any static host.
 
 ## 📁 Structure
 
-```
+```text
 bytestreams/
 ├── index.html
+├── privacy.html
+├── terms.html
+├── cookies.html
 ├── js/main.js
 ├── sass/
 │   ├── abstracts/   # _variables.scss, _mixins.scss (brand tokens)
@@ -62,9 +69,8 @@ bytestreams/
 │   ├── pages/       # _home.scss
 │   └── main.scss    # entry point
 ├── dist/css/main.css   # generated — do not edit
-├── assets/logo.svg, favicon.svg
-├── site/               # reference screenshots
-├── branding.md         # condensed brand notes
+├── assets/             # logos, favicon, brand marks
+├── docs/               # policy and campaign copy/source docs
 └── ByteStreams-Brand-Kit.pdf  # full brand kit v1.0
 ```
 

--- a/cookies.html
+++ b/cookies.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ByteStreams Cookie Policy.">
+    <meta name="theme-color" content="#0D1117">
+    <title>Cookie Policy &mdash; ByteStreams</title>
+
+    <link rel="icon" type="image/svg+xml" href="assets/bytestreams-icon-256.svg">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+    <link rel="stylesheet" href="dist/css/main.css">
+</head>
+<body data-theme="dark">
+    <!-- ============== Header ============== -->
+    <header class="header" id="siteHeader">
+        <div class="header__container">
+            <div class="header__brand">
+                <a href="index.html#home" class="header__logo" aria-label="ByteStreams &mdash; home">
+                    <img src="assets/blue-side-slim-logo.png" alt="ByteStreams" class="header__logo-mark" width="198" height="56">
+                </a>
+                <p class="header__tagline">Smarter Workflows, Stronger Results.</p>
+            </div>
+
+            <nav class="header__nav" id="primaryNav" aria-label="Primary">
+                <ul class="header__nav-list">
+                    <li><a href="index.html#home" class="header__nav-link">Home</a></li>
+                    <li><a href="index.html#features" class="header__nav-link">Features</a></li>
+                    <li><a href="index.html#about" class="header__nav-link">About</a></li>
+                    <li><a href="index.html#contact" class="header__nav-link">Contact</a></li>
+                </ul>
+            </nav>
+
+            <div class="header__actions">
+                <a href="index.html#contact" class="btn btn--primary btn--sm">Get Started</a>
+                <button class="header__hamburger" id="hamburgerBtn"
+                        aria-label="Toggle navigation"
+                        aria-controls="primaryNav"
+                        aria-expanded="false">
+                    <span></span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <!-- ============== Content ============== -->
+    <main class="section">
+        <div class="section__container">
+            <header class="section__header">
+                <h1 class="section__title">Cookie Policy</h1>
+                <p class="section__subtitle">Last updated: April 21, 2026</p>
+            </header>
+
+            <article class="legal-doc">
+                <p>
+                    This Cookie Policy explains how bytestreams (<strong>&quot;Company&quot;</strong>, <strong>&quot;we&quot;</strong>,
+                    <strong>&quot;us&quot;</strong>, and <strong>&quot;our&quot;</strong>) uses cookies and similar technologies to recognize you when you visit our
+                    website at <a href="https://bytestreams.ai">https://bytestreams.ai</a> (<strong>&quot;Website&quot;</strong>). It explains what these
+                    technologies are and why we use them, as well as your rights to control our use of them.
+                </p>
+
+                <p>
+                    In some cases we may use cookies to collect personal information, or that becomes personal information if we combine it with other information.
+                </p>
+
+                <h2>What are cookies?</h2>
+                <p>
+                    Cookies are small data files that are placed on your computer or mobile device when you visit a website. Cookies are widely used by website owners in order to make their websites work, or to work more efficiently, as well as to provide reporting information.
+                </p>
+
+                <p>
+                    Cookies set by the website owner (in this case, bytestreams) are called &quot;first-party cookies.&quot; Cookies set by parties other than the website owner are called &quot;third-party cookies.&quot; Third-party cookies enable third-party features or functionality to be provided on or through the website (e.g., advertising, interactive content, and analytics). The parties that set these third-party cookies can recognize your computer both when it visits the website in question and also when it visits certain other websites.
+                </p>
+
+                <h2>Why do we use cookies?</h2>
+                <p>
+                    We use first- and third-party cookies for several reasons. Some cookies are required for technical reasons in order for our Website to operate, and we refer to these as &quot;essential&quot; or &quot;strictly necessary&quot; cookies. Other cookies also enable us to track and target the interests of our users to enhance the experience on our Online Properties. Third parties serve cookies through our Website for advertising, analytics, and other purposes. This is described in more detail below.
+                </p>
+
+                <h2>How can I control cookies on my browser?</h2>
+                <p>
+                    As the means by which you can refuse cookies through your web browser controls vary from browser to browser, you should visit your browser's help menu for more information. The following is information about how to manage cookies on the most popular browsers:
+                </p>
+
+                <ul>
+                    <li><a href="https://support.google.com/chrome/answer/95647">Chrome</a></li>
+                    <li><a href="https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer">Firefox</a></li>
+                    <li><a href="https://support.apple.com/guide/safari/manage-cookies-sfri11471/mac">Safari</a></li>
+                    <li><a href="https://support.microsoft.com/en-us/microsoft-edge/delete-cookies-in-microsoft-edge-63947406-40ac-c3b8-57b9-2a946a29ae09">Edge</a></li>
+                    <li><a href="https://help.opera.com/en/latest/web-preferences/">Opera</a></li>
+                    <li><a href="https://www.youradchoices.com/">Digital Advertising Alliance</a></li>
+                    <li><a href="https://youradchoices.ca/">DAA Canada</a></li>
+                    <li><a href="https://www.youronlinechoices.eu/">EDAA</a></li>
+                </ul>
+
+                <p>
+                    In addition, most advertising networks offer you a way to opt out of targeted advertising. If you would like to find out more information, please visit:
+                </p>
+
+                <ul>
+                    <li>Digital Advertising Alliance</li>
+                    <li>Digital Advertising Alliance of Canada</li>
+                    <li>European Interactive Digital Advertising Alliance</li>
+                </ul>
+
+                <h2>What about other tracking technologies, like web beacons?</h2>
+                <p>
+                    Cookies are not the only way to recognize or track visitors to a website. We may use other, similar technologies from time to time, like web beacons (sometimes called &quot;tracking pixels&quot; or &quot;clear gifs&quot;). These are tiny graphics files that contain a unique identifier that enables us to recognize when someone has visited our Website or opened an email including them. This allows us, for example, to monitor the traffic patterns of users from one page within a website to another, to deliver or communicate with cookies, to understand whether you have come to the website from an online advertisement displayed on a third-party website, to improve site performance, and to measure the success of email marketing campaigns. In many instances, these technologies are reliant on cookies to function properly, and so declining cookies will impair their functioning.
+                </p>
+
+                <h2>Do you use Flash cookies or Local Shared Objects?</h2>
+                <p>
+                    Websites may also use so-called &quot;Flash Cookies&quot; (also known as Local Shared Objects or &quot;LSOs&quot;) to, among other things, collect and store information about your use of our services, fraud prevention, and for other site operations.
+                </p>
+
+                <p>
+                    If you do not want Flash Cookies stored on your computer, you can adjust the settings of your Flash player to block Flash Cookies storage using the tools contained in the <a href="https://www.macromedia.com/support/documentation/en/flashplayer/help/settings_manager07.html">Website Storage Settings Panel</a>. You can also control Flash Cookies by going to the <a href="https://www.macromedia.com/support/documentation/en/flashplayer/help/settings_manager03.html">Global Storage Settings Panel</a> and following the instructions (which may include instructions that explain, for example, how to delete existing Flash Cookies (referred to as &quot;information&quot; on the Macromedia site), how to prevent Flash LSOs from being placed on your computer without your being asked, and (for Flash Player 8 and later) how to block Flash Cookies that are not being delivered by the operator of the page you are on at the time).
+                </p>
+
+                <p>
+                    Please note that setting the Flash Player to restrict or limit acceptance of Flash Cookies may reduce or impede the functionality of some Flash applications, including, potentially, Flash applications used in connection with our services or online content.
+                </p>
+
+                <h2>Do you serve targeted advertising?</h2>
+                <p>
+                    Third parties may serve cookies on your computer or mobile device to serve advertising through our Website. These companies may use information about your visits to this and other websites in order to provide relevant advertisements about goods and services that you may be interested in. They may also employ technology that is used to measure the effectiveness of advertisements. They can accomplish this by using cookies or web beacons to collect information about your visits to this and other sites in order to provide relevant advertisements about goods and services of potential interest to you. The information collected through this process does not enable us or them to identify your name, contact details, or other details that directly identify you unless you choose to provide these.
+                </p>
+
+                <h2>How often will you update this Cookie Policy?</h2>
+                <p>
+                    We may update this Cookie Policy from time to time in order to reflect, for example, changes to the cookies we use or for other operational, legal, or regulatory reasons. Please therefore revisit this Cookie Policy regularly to stay informed about our use of cookies and related technologies.
+                </p>
+
+                <p>
+                    The date at the top of this Cookie Policy indicates when it was last updated.
+                </p>
+
+                <h2>Where can I get further information?</h2>
+                <p>
+                    If you have any questions about our use of cookies or other technologies, please email us at <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a> or by post to:
+                </p>
+
+                <p>
+                    ByteStreams<br>
+                    501 Union St<br>
+                    Nashville, TN 38219<br>
+                    United States<br>
+                    Phone: +1 629 282 9555
+                </p>
+            </article>
+        </div>
+    </main>
+
+    <!-- ============== Footer ============== -->
+    <footer class="footer">
+        <div class="footer__container">
+            <div class="footer__grid">
+                <div class="footer__brand">
+                    <a href="index.html#home" class="footer__logo" aria-label="ByteStreams &mdash; home">
+                        <img src="assets/blue-side-slim-logo.png" alt="ByteStreams" width="198" height="56">
+                    </a>
+                    <p class="footer__tagline">
+                        Smarter Workflows, Stronger Results.
+                    </p>
+                </div>
+
+                <div class="footer__site-map" aria-label="Footer site links">
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Company</p>
+                        <ul class="footer__site-links">
+                            <li><a href="index.html#about" class="footer__link">About</a></li>
+                            <li><a href="#" class="footer__link">Security</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Product</p>
+                        <ul class="footer__site-links">
+                            <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="index.html#features" class="footer__link">Features</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Legal</p>
+                        <ul class="footer__site-links">
+                            <li><a href="privacy.html" class="footer__link">Privacy</a></li>
+                            <li><a href="terms.html" class="footer__link">Terms</a></li>
+                            <li><a href="sms-terms.html" class="footer__link">SMS Terms</a></li>
+                            <li><a href="cookies.html" class="footer__link">Cookie Policy</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <div class="footer__bottom">
+                <p class="footer__copyright">
+                    &copy; 2026 ByteStreams. Smarter Workflows, Stronger Results.
+                </p>
+                <div class="footer__social" aria-label="Social links">
+                    <a href="#" class="footer__social-link" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in" aria-hidden="true"></i></a>
+                    <a href="#" class="footer__social-link" aria-label="X / Twitter"><i class="fa-brands fa-x-twitter" aria-hidden="true"></i></a>
+                    <a href="#" class="footer__social-link" aria-label="GitHub"><i class="fa-brands fa-github" aria-hidden="true"></i></a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/cookies.html
+++ b/cookies.html
@@ -54,104 +54,73 @@
         <div class="section__container">
             <header class="section__header">
                 <h1 class="section__title">Cookie Policy</h1>
-                <p class="section__subtitle">Last updated: April 21, 2026</p>
+                <p class="section__subtitle">Last updated: April 22, 2026</p>
             </header>
 
             <article class="legal-doc">
                 <p>
                     This Cookie Policy explains how bytestreams (<strong>&quot;Company&quot;</strong>, <strong>&quot;we&quot;</strong>,
-                    <strong>&quot;us&quot;</strong>, and <strong>&quot;our&quot;</strong>) uses cookies and similar technologies to recognize you when you visit our
-                    website at <a href="https://bytestreams.ai">https://bytestreams.ai</a> (<strong>&quot;Website&quot;</strong>). It explains what these
-                    technologies are and why we use them, as well as your rights to control our use of them.
+                    <strong>&quot;us&quot;</strong>, and <strong>&quot;our&quot;</strong>) handles cookies and similar tracking technologies on
+                    <a href="https://bytestreams.ai">https://bytestreams.ai</a> (<strong>&quot;Website&quot;</strong>).
                 </p>
 
                 <p>
-                    In some cases we may use cookies to collect personal information, or that becomes personal information if we combine it with other information.
+                    <strong>Current status:</strong> We do <strong>not</strong> use cookies on this Website.
                 </p>
 
-                <h2>What are cookies?</h2>
+                <h2>Do we use cookies?</h2>
                 <p>
-                    Cookies are small data files that are placed on your computer or mobile device when you visit a website. Cookies are widely used by website owners in order to make their websites work, or to work more efficiently, as well as to provide reporting information.
+                    No. bytestreams.ai does not set first-party cookies, does not use third-party advertising cookies, and
+                    does not run cookie-based analytics.
                 </p>
 
+                <h2>Do we use similar tracking technologies?</h2>
                 <p>
-                    Cookies set by the website owner (in this case, bytestreams) are called &quot;first-party cookies.&quot; Cookies set by parties other than the website owner are called &quot;third-party cookies.&quot; Third-party cookies enable third-party features or functionality to be provided on or through the website (e.g., advertising, interactive content, and analytics). The parties that set these third-party cookies can recognize your computer both when it visits the website in question and also when it visits certain other websites.
+                    No. We do not use tracking pixels, web beacons, or browser fingerprinting technologies on this Website
+                    for advertising or behavioral tracking.
                 </p>
 
-                <h2>Why do we use cookies?</h2>
+                <h2>How does this align with our services?</h2>
                 <p>
-                    We use first- and third-party cookies for several reasons. Some cookies are required for technical reasons in order for our Website to operate, and we refer to these as &quot;essential&quot; or &quot;strictly necessary&quot; cookies. Other cookies also enable us to track and target the interests of our users to enhance the experience on our Online Properties. Third parties serve cookies through our Website for advertising, analytics, and other purposes. This is described in more detail below.
+                    ByteStreams and related DialTone flows are primarily SMS-driven rather than browser-session-driven.
+                    Customer interactions are handled through phone and SMS channels, not cookie-based web user profiling.
                 </p>
 
-                <h2>How can I control cookies on my browser?</h2>
+                <h2>What information do we collect on the Website?</h2>
                 <p>
-                    As the means by which you can refuse cookies through your web browser controls vary from browser to browser, you should visit your browser's help menu for more information. The following is information about how to manage cookies on the most popular browsers:
+                    The Website may collect information you actively submit (for example, through contact forms or direct
+                    email communication). That collection is not cookie-based.
                 </p>
 
-                <ul>
-                    <li><a href="https://support.google.com/chrome/answer/95647">Chrome</a></li>
-                    <li><a href="https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer">Firefox</a></li>
-                    <li><a href="https://support.apple.com/guide/safari/manage-cookies-sfri11471/mac">Safari</a></li>
-                    <li><a href="https://support.microsoft.com/en-us/microsoft-edge/delete-cookies-in-microsoft-edge-63947406-40ac-c3b8-57b9-2a946a29ae09">Edge</a></li>
-                    <li><a href="https://help.opera.com/en/latest/web-preferences/">Opera</a></li>
-                    <li><a href="https://www.youradchoices.com/">Digital Advertising Alliance</a></li>
-                    <li><a href="https://youradchoices.ca/">DAA Canada</a></li>
-                    <li><a href="https://www.youronlinechoices.eu/">EDAA</a></li>
-                </ul>
-
+                <h2>SMS and third-party providers</h2>
                 <p>
-                    In addition, most advertising networks offer you a way to opt out of targeted advertising. If you would like to find out more information, please visit:
+                    SMS delivery for our product workflows may involve telecommunications providers (for example, Twilio)
+                    in operational systems. Those SMS operations are separate from cookie use on this Website and do not
+                    depend on cookies in your browser.
                 </p>
 
-                <ul>
-                    <li>Digital Advertising Alliance</li>
-                    <li>Digital Advertising Alliance of Canada</li>
-                    <li>European Interactive Digital Advertising Alliance</li>
-                </ul>
-
-                <h2>What about other tracking technologies, like web beacons?</h2>
+                <h2>Do I need to change browser cookie settings?</h2>
                 <p>
-                    Cookies are not the only way to recognize or track visitors to a website. We may use other, similar technologies from time to time, like web beacons (sometimes called &quot;tracking pixels&quot; or &quot;clear gifs&quot;). These are tiny graphics files that contain a unique identifier that enables us to recognize when someone has visited our Website or opened an email including them. This allows us, for example, to monitor the traffic patterns of users from one page within a website to another, to deliver or communicate with cookies, to understand whether you have come to the website from an online advertisement displayed on a third-party website, to improve site performance, and to measure the success of email marketing campaigns. In many instances, these technologies are reliant on cookies to function properly, and so declining cookies will impair their functioning.
+                    Since we do not use cookies on this Website, no cookie preference tool is required for bytestreams.ai
+                    at this time. You can still manage browser cookie settings globally if you prefer.
                 </p>
 
-                <h2>Do you use Flash cookies or Local Shared Objects?</h2>
+                <h2>How often will this policy be updated?</h2>
                 <p>
-                    Websites may also use so-called &quot;Flash Cookies&quot; (also known as Local Shared Objects or &quot;LSOs&quot;) to, among other things, collect and store information about your use of our services, fraud prevention, and for other site operations.
+                    We may update this Cookie Policy if our practices change. If we begin using cookies or similar tracking
+                    technologies, we will update this page and revise the date shown at the top.
                 </p>
 
+                <h2>Where can I get more information?</h2>
                 <p>
-                    If you do not want Flash Cookies stored on your computer, you can adjust the settings of your Flash player to block Flash Cookies storage using the tools contained in the <a href="https://www.macromedia.com/support/documentation/en/flashplayer/help/settings_manager07.html">Website Storage Settings Panel</a>. You can also control Flash Cookies by going to the <a href="https://www.macromedia.com/support/documentation/en/flashplayer/help/settings_manager03.html">Global Storage Settings Panel</a> and following the instructions (which may include instructions that explain, for example, how to delete existing Flash Cookies (referred to as &quot;information&quot; on the Macromedia site), how to prevent Flash LSOs from being placed on your computer without your being asked, and (for Flash Player 8 and later) how to block Flash Cookies that are not being delivered by the operator of the page you are on at the time).
+                    If you have questions about this Cookie Policy, please email us at
+                    <a href="mailto:privacy@bytestreams.com">privacy@bytestreams.com</a>.
                 </p>
 
                 <p>
-                    Please note that setting the Flash Player to restrict or limit acceptance of Flash Cookies may reduce or impede the functionality of some Flash applications, including, potentially, Flash applications used in connection with our services or online content.
-                </p>
-
-                <h2>Do you serve targeted advertising?</h2>
-                <p>
-                    Third parties may serve cookies on your computer or mobile device to serve advertising through our Website. These companies may use information about your visits to this and other websites in order to provide relevant advertisements about goods and services that you may be interested in. They may also employ technology that is used to measure the effectiveness of advertisements. They can accomplish this by using cookies or web beacons to collect information about your visits to this and other sites in order to provide relevant advertisements about goods and services of potential interest to you. The information collected through this process does not enable us or them to identify your name, contact details, or other details that directly identify you unless you choose to provide these.
-                </p>
-
-                <h2>How often will you update this Cookie Policy?</h2>
-                <p>
-                    We may update this Cookie Policy from time to time in order to reflect, for example, changes to the cookies we use or for other operational, legal, or regulatory reasons. Please therefore revisit this Cookie Policy regularly to stay informed about our use of cookies and related technologies.
-                </p>
-
-                <p>
-                    The date at the top of this Cookie Policy indicates when it was last updated.
-                </p>
-
-                <h2>Where can I get further information?</h2>
-                <p>
-                    If you have any questions about our use of cookies or other technologies, please email us at <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a> or by post to:
-                </p>
-
-                <p>
-                    ByteStreams<br>
-                    501 Union St<br>
-                    Nashville, TN 38219<br>
-                    United States<br>
-                    Phone: +1 629 282 9555
+                    bytestreams LLC<br>
+                    Privacy Team<br>
+                    [Company Address]
                 </p>
             </article>
         </div>

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -230,6 +230,34 @@ em {
   color: inherit;
 }
 
+.legal-doc {
+  max-width: 840px;
+  margin: 0 auto;
+}
+.legal-doc p,
+.legal-doc ul {
+  margin-bottom: 16px;
+}
+.legal-doc h2 {
+  margin-top: 48px;
+  margin-bottom: 16px;
+}
+.legal-doc ul {
+  list-style: disc;
+  padding-left: 24px;
+  color: var(--text-muted);
+}
+.legal-doc li {
+  margin-bottom: 8px;
+  line-height: 1.6;
+}
+.legal-doc strong {
+  color: var(--text);
+}
+.legal-doc a {
+  word-break: break-word;
+}
+
 .header {
   position: sticky;
   top: 0;
@@ -418,12 +446,12 @@ em {
 }
 .footer__grid {
   display: grid;
-  grid-template-columns: 1.5fr repeat(3, 1fr);
+  grid-template-columns: minmax(220px, 1.2fr) minmax(420px, 2.8fr);
   gap: 48px;
 }
 @media (max-width: 900px) {
   .footer__grid {
-    grid-template-columns: 1.2fr repeat(3, 1fr);
+    grid-template-columns: 1fr;
     gap: 32px;
   }
 }
@@ -478,6 +506,48 @@ em {
 }
 .footer__link:hover {
   color: #3B82F6;
+}
+.footer__site-map {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-self: center;
+}
+.footer__site-row {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 16px;
+  align-items: baseline;
+}
+@media (max-width: 599px) {
+  .footer__site-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+}
+.footer__site-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+  letter-spacing: 0.02em;
+}
+.footer__site-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.footer__site-links li {
+  display: inline-flex;
+  align-items: center;
+}
+.footer__site-links li + li::before {
+  content: "->";
+  color: var(--text-faded);
+  margin-right: 8px;
 }
 .footer__bottom {
   border-top: 1px solid var(--border);

--- a/docs/10dlc-bytestreams-internal.md
+++ b/docs/10dlc-bytestreams-internal.md
@@ -1,0 +1,226 @@
+# 10DLC Campaign Submission — ByteStreams LLC Internal Operations
+
+**Purpose:** This is ByteStreams LLC's first 10DLC campaign, filed before any restaurant-facing campaigns. It registers a simple, low-risk internal notification flow that (1) establishes ByteStreams as an approved Brand, (2) builds a clean Trust Score track record with TCR and the carriers, and (3) demonstrates the CSP is operational before onboarding the first pilot restaurant.
+
+**What this campaign is NOT:** It does not cover any messages to restaurant operators, restaurant diners, or any external recipient. It is strictly internal operations alerts to ByteStreams team members who have explicitly authorized their own mobile numbers to receive system notifications.
+
+**Filing order:** This campaign first. Wait for approval + 30 clean days. Then file restaurant-operator campaigns and restaurant-customer campaigns as separate submissions.
+
+---
+
+## Brand Registration (Do This First)
+
+Before the Campaign can be submitted, ByteStreams LLC must be registered as a Brand with The Campaign Registry. Use real values only:
+
+| Field | Value |
+|---|---|
+| Legal business name | **ByteStreams LLC** *(verify exact capitalization against your SS-4 / Articles of Organization before submitting — mismatches are a top rejection trigger)* |
+| EIN | *(from your IRS SS-4 letter)* |
+| Business address | 501 Union St Ste 545, Nashville, TN 37219 |
+| Country of registration | United States |
+| State of registration | Tennessee |
+| Business type | Private Company / LLC |
+| Vertical | Technology / Professional Services |
+| Website | https://bytestreams.ai |
+| Support email | hello@bytestreams.ai |
+| Support phone | 629-282-9555 |
+| Brand contact (authorized rep) | *(your name, title, business email — not Gmail)* |
+
+**Before submitting the Brand:**
+- bytestreams.ai must resolve over HTTPS with real content (not a placeholder)
+- `/privacy` must be live and readable
+- `/sms-terms` must be live and readable
+- The website must clearly identify ByteStreams LLC, its address, and its business purpose
+- Contact information on the site must match what's on the Brand registration
+
+Brand registrations typically take 2–5 business days. Campaigns cannot be submitted until the Brand is approved.
+
+---
+
+## Campaign Registration Fields
+
+### Use Case Type
+
+**Account Notification** *(single use case — do NOT select Mixed for this campaign)*
+
+This is the cleanest possible use case for an internal operations campaign. Reviewers see it routinely and approve it quickly when the supporting details are tight.
+
+---
+
+### Campaign Description
+
+> ByteStreams LLC operates DialTone, an AI voice ordering platform for restaurants. This campaign covers internal operational notifications sent only to authorized ByteStreams team members (currently a small set of technical staff) who have explicitly registered their mobile numbers in the internal admin system to receive alerts about production systems.
+>
+> Messages include: (a) production system alerts such as failed API calls to third-party services, elevated error rates, or health check failures; (b) Stripe webhook delivery failures; (c) deployment notifications when a new version of the platform is released; (d) on-call paging when a critical system component is unavailable. No messages are sent to restaurant operators, restaurant customers, or any external recipient under this campaign.
+>
+> Team members opt in by logging into the internal admin dashboard at admin.bytestreams.ai, navigating to their personal notification preferences page, entering their mobile number, and affirmatively enabling SMS alerts through a checkbox interface. Each opt-in is logged with the team member's user ID, timestamp, IP address, and the exact consent language shown at the time of opt-in. Team members may disable SMS alerts at any time via the same dashboard or by replying STOP to any message.
+
+**Why this description works:**
+
+- Narrow scope: internal team members only. No external recipients.
+- Names the platform (DialTone) and the company (ByteStreams LLC) so reviewers can verify consistency with the Brand.
+- Lists message types concretely — not "alerts and notifications" but specifically "API failures, webhook failures, deployments, on-call paging."
+- Describes opt-in with enough detail that a reviewer can picture the flow without visiting the dashboard (they can't — it's behind auth).
+- Explicitly rules out the failure modes reviewers worry about ("no messages to external recipients").
+- Includes STOP keyword.
+
+---
+
+### Call-to-Action / Message Flow
+
+> Opt-in is restricted to authorized ByteStreams team members. The flow is:
+>
+> 1. Team member is granted access to admin.bytestreams.ai as part of their employment or contracting agreement with ByteStreams LLC.
+> 2. Team member logs into the admin dashboard using SSO or password authentication.
+> 3. Team member navigates to Settings → Notification Preferences.
+> 4. Team member enters their personal mobile number in the "SMS alerts number" field.
+> 5. Team member checks an unchecked consent checkbox directly above the Save button reading: "☐ Send operational SMS alerts to this number. Message frequency varies based on system activity. Message and data rates may apply. Reply STOP to unsubscribe. See our SMS Terms at bytestreams.ai/sms-terms."
+> 6. Team member clicks Save. A verification SMS is immediately sent to the provided number with language: "ByteStreams: Your number is now registered for system alerts. Reply STOP to cancel. Reply HELP for help."
+> 7. Opt-in is logged with: team member user ID, mobile number, timestamp, IP address, user agent, and the version of the consent language shown.
+>
+> Numbers are never added without the account holder's own action. There is no bulk upload, no import from a list, no automated enrollment.
+
+**Why this flow works:**
+
+- Describes exactly where the opt-in happens (admin.bytestreams.ai, a specific page, a specific field)
+- Describes the checkbox as unchecked by default
+- Quotes the exact consent language verbatim
+- Describes the double-opt-in confirmation (verification SMS)
+- Rules out the failure modes reviewers worry about (bulk upload, list imports, auto-enrollment)
+
+---
+
+### Sample Messages
+
+Four sample messages. Each begins with the brand name and ends with STOP language.
+
+**Sample 1 — Opt-in Verification (sent immediately after consent)**
+> ByteStreams: Your number is now registered for system alerts. Msg freq varies. Msg & data rates may apply. Reply HELP for help, STOP to cancel.
+
+**Sample 2 — Production Alert**
+> ByteStreams Alert: Vapi API error rate elevated above threshold (4.2% over last 5 min). Dashboard: https://admin.bytestreams.ai/ops. Reply STOP to opt out.
+
+**Sample 3 — Deployment Notification**
+> ByteStreams: Deploy v1.4.2 to production completed successfully at 02:14 UTC. 0 errors in post-deploy check. Reply STOP to opt out.
+
+**Sample 4 — HELP Response**
+> ByteStreams: For help with system alerts, contact hello@bytestreams.ai or 629-282-9555. Msg & data rates may apply. Reply STOP to cancel.
+
+**Why these work:**
+
+- Every sample begins with "ByteStreams" — brand name is explicit
+- Every sample ends with STOP (or HELP/STOP in sample 4)
+- Samples are clearly internal-ops in nature — no hint of marketing, transactions, or external recipient communication
+- Sample 2 contains a link to admin.bytestreams.ai (auth-gated, which reviewers can verify)
+- Sample 3 is a concrete, realistic deploy notification — not a placeholder
+
+---
+
+### Embedded Links
+
+**Yes.** Some alert messages contain links to admin.bytestreams.ai (for example, "Dashboard: admin.bytestreams.ai/ops"). All links resolve to the ByteStreams admin domain, which is authenticated and accessible only to team members.
+
+---
+
+### Embedded Phone Numbers
+
+**Yes.** The HELP response contains the ByteStreams support phone number (629-282-9555).
+
+---
+
+### Age-Gated Content
+
+**No.** Internal operational alerts. No alcohol, tobacco, cannabis, firearms, gambling, or age-restricted content.
+
+---
+
+### Number Pooling
+
+**No.** A single dedicated 10DLC number is used for this campaign.
+
+---
+
+### Direct Lending Arrangement
+
+**No.**
+
+---
+
+### Subscriber Opt-In
+
+**Yes** — as described in the Call-to-Action section above.
+
+---
+
+### Subscriber Opt-Out
+
+**Yes.** Team members may reply STOP, END, CANCEL, UNSUBSCRIBE, or QUIT at any time. Opt-outs are processed automatically by the platform. A final confirmation is sent:
+
+> ByteStreams: You've opted out of system alerts. To re-enable, log into admin.bytestreams.ai. Reply START to resubscribe.
+
+---
+
+### Subscriber Help
+
+**Yes.** Replies of HELP or INFO receive the HELP response (Sample 4 above).
+
+---
+
+## Required Website Elements
+
+Before submitting this campaign, the following must be live at bytestreams.ai:
+
+1. **Homepage** at https://bytestreams.ai describing ByteStreams LLC and DialTone in plain language. Must clearly identify the company and its business purpose.
+
+2. **Privacy Policy** at https://bytestreams.ai/privacy. For this campaign specifically, it must include:
+   - A section on SMS / text messaging
+   - Explicit language: "SMS opt-in data is not shared with third parties for marketing or promotional purposes"
+   - Contact information matching the Brand registration
+
+3. **SMS Terms** at https://bytestreams.ai/sms-terms. The page I built for you earlier covers this — confirm it's live before submitting.
+
+4. **About or Contact page** identifying ByteStreams LLC as a Tennessee limited liability company with the Nashville address matching the Brand registration.
+
+5. The admin dashboard at admin.bytestreams.ai does not need to be publicly accessible, but the login page should at minimum render (not a 404). Reviewers may click the domain to verify it resolves.
+
+**If any of the above is missing or returns a 404, the campaign will be rejected.**
+
+---
+
+## What This Campaign Establishes for Your Trust Score
+
+A clean approval on this campaign gives ByteStreams:
+
+1. An approved Brand (reusable for all future restaurant campaigns — you don't re-register the Brand every time)
+2. A track record of successful campaign operation as a CSP
+3. Evidence to carriers that ByteStreams operates compliant infrastructure
+4. A reference campaign to point to when restaurant-operator and restaurant-customer campaigns are submitted later
+
+**Keep this campaign tidy during the first 30 days:**
+- Actual sent volume should be low and consistent with the stated use case (production alerts happen, but not at marketing frequencies)
+- No spam complaints (trivially easy when the only recipients are your team)
+- No opt-out spikes
+- Every sent message should match one of the approved sample types — don't drift the content
+
+**Then, around day 30–45:**
+- Submit the restaurant-operator notification campaign (for DialTone account holders — signup confirmations, billing alerts, security notifications)
+- Onboard your first pilot restaurant and file their restaurant-customer campaign (the one in `10dlc-campaign-submission.md`)
+
+Your CSP track record at that point will be: one clean internal campaign running for 30+ days, zero rejections, zero complaints. Restaurant campaigns submitted from that position have meaningfully better approval odds than first-time CSP submissions.
+
+---
+
+## Fields to Confirm Before Submitting
+
+Unlike the restaurant-facing campaign template, this submission uses real ByteStreams data everywhere. Before clicking submit, verify:
+
+- [ ] Exact legal entity name on the Brand form matches the SS-4 / Articles of Organization
+- [ ] EIN on the Brand form matches the IRS letter
+- [ ] Business address is current (not a prior address if you've moved)
+- [ ] bytestreams.ai resolves over HTTPS
+- [ ] /privacy is live with SMS-specific language and the "not shared with third parties" statement
+- [ ] /sms-terms is live and matches the flow described in this submission
+- [ ] admin.bytestreams.ai at minimum shows a login page (not a 404)
+- [ ] The support email is a business email on the bytestreams.ai domain (not Gmail)
+- [ ] All sample messages read naturally and include "ByteStreams" plus STOP language
+- [ ] The Brand is approved before this Campaign is submitted (submitting the Campaign before the Brand is approved causes confusing errors)

--- a/docs/10dlc-campaign-submission.md
+++ b/docs/10dlc-campaign-submission.md
@@ -1,0 +1,259 @@
+# 10DLC Campaign Submission — DialTone (ByteStreams LLC)
+
+**Registration model:** ISV / Reseller. Each restaurant client will register their own Brand and Campaign via ByteStreams as the CSP. This document is the **template** that each restaurant's submission will follow, with per-restaurant fields noted in `{{ double_braces }}`.
+
+**About this revision:** This submission reflects DialTone's actual end-to-end flow. The critical detail a reviewer needs to understand — and your previous submission likely missed — is that **the Stripe payment link SMS is the mechanism by which an order is completed**. Consent is captured verbally at the start of the call, before order-taking begins, because without consent the payment link cannot be sent and the order cannot be placed. Every field below is written to make this flow transparent and verifiable to a carrier reviewer.
+
+---
+
+## Campaign Registration Fields
+
+### Use Case Type
+
+**Mixed Use Case** — covers three distinct message purposes within a single customer relationship:
+
+- **Customer Care / Account Notification** — payment link, order confirmation, order-ready status
+- **Delivery Notifications** — when delivery is supported (out-for-delivery updates)
+- **Marketing** — occasional promotional messages, only to customers who separately opt in
+
+*If the messaging provider's form forces single-purpose campaigns: split into two campaigns. The primary campaign is "Mixed (Customer Care + Delivery)" covering all transactional messages — this must be approved before the restaurant can take orders at all. A secondary "Marketing" campaign is registered only for restaurants on the Marketing add-on. Do not combine promotional sends into the transactional campaign.*
+
+---
+
+### Campaign Description
+
+> {{Restaurant_Name}} is a {{cuisine_type}} restaurant located at {{full_street_address}}, operating in Tennessee / {{state}}. {{Restaurant_Name}} uses DialTone, an AI voice ordering platform operated by ByteStreams LLC (a Tennessee LLC), to answer inbound customer calls and process food orders.
+>
+> When a customer calls {{Restaurant_Phone}}, DialTone's AI voice agent answers, captures verbal SMS consent at the start of the call, and then takes the customer's order. Once the order is finalized, DialTone sends the customer a Stripe payment link via SMS. After the customer completes payment through Stripe Checkout, DialTone sends a payment confirmation SMS containing the order details, followed by a "your order is ready" SMS when the restaurant marks the order complete. Customers who also opt in to promotional messages may receive occasional offers from {{Restaurant_Name}}, no more than two (2) per month.
+>
+> Consent is captured verbally during the phone call and the call is recorded. An alternate consent channel is available on {{Restaurant_Website_URL}} via an unchecked consent checkbox on the online ordering form. All messages are sent on behalf of {{Restaurant_Name}}, identify {{Restaurant_Name}} as the sender, and include opt-out language (Reply STOP). Customers who decline SMS consent during the call are politely offered a transfer to restaurant staff so their order can be placed manually.
+
+**Why this works:**
+
+- Explicitly names the business, cuisine, and physical address (reviewer can verify)
+- Explicitly describes DialTone's role — prevents the reviewer from thinking this is direct-to-consumer ByteStreams messaging
+- **Leads with the payment link SMS as the core transactional message** — this is the critical detail that justifies why SMS is required and why consent is captured upfront
+- Specifies message types in order of occurrence: consent capture → payment link → payment confirmation → order ready → optional promotional
+- Specifies promotional frequency limit (2/month)
+- States what happens when consent is refused (transfer to staff) — this preempts the reviewer's "what if someone doesn't want texts?" objection
+- Identifies the STOP keyword
+
+---
+
+### Call-to-Action / Message Flow *(how users opt in)*
+
+> Customers opt in through one of two channels:
+>
+> **(1) Voice opt-in at the start of a phone order.** When a customer calls {{Restaurant_Name}} at {{Restaurant_Phone}}, DialTone's AI voice agent answers and captures SMS consent before taking the order. The agent says:
+>
+> "Thanks for calling {{Restaurant_Name}}! I can take your order right now. Just so you know, to finish your order I'll need to text you a payment link from Stripe, and I'll also text you a confirmation when payment clears and another text when your order is ready. Message and data rates may apply, and you can reply STOP anytime to unsubscribe. Is it OK to text you at the number you're calling from?"
+>
+> If the customer says yes, the agent confirms the last four digits of the calling number and proceeds to take the order. If the customer says no, the agent responds: "No problem — let me transfer you to the restaurant so they can take your order directly. One moment." The call is transferred to the restaurant's staff line.
+>
+> Verbal consent is recorded, time-stamped, and retained with a transcript excerpt showing the exact consent moment. No order is taken until consent has been captured.
+>
+> **(2) Website opt-in at {{Restaurant_Website_URL}}/order.** When a customer places an order through the restaurant's online ordering page, the form includes an unchecked consent checkbox directly above the submit button:
+>
+> "☐ Yes, text me a Stripe payment link, order confirmation, and pickup/delivery updates from {{Restaurant_Name}}. Message frequency varies. Message and data rates may apply. Reply STOP to unsubscribe. See our Privacy Policy at {{Restaurant_Website_URL}}/privacy and SMS Terms at {{Restaurant_Website_URL}}/sms-terms."
+>
+> Below it, a separate, also-unchecked checkbox for promotional opt-in:
+>
+> "☐ Also text me occasional offers from {{Restaurant_Name}}, up to 2 per month. Reply STOP to unsubscribe."
+>
+> Both checkboxes are unchecked by default. Transactional consent is required to submit the form; promotional consent is optional. The submission timestamp, IP address, user agent, and the exact consent language shown at the time of submission are logged.
+
+**Why this works:**
+
+- Two concrete channels, both fully described
+- **Exact consent language is quoted verbatim**, not paraphrased — reviewers can compare it to what's on the website and what's on the call recording
+- Addresses how consent refusal is handled (transfer to staff) — this is a key differentiator from generic "we ask, if they say no, we don't text them" flows
+- Describes the consent *logging* in detail (timestamp, transcript excerpt, IP address) — reviewers want to know the evidence trail is real
+- Transactional and promotional consent are clearly separated
+- Checkboxes are explicitly unchecked by default (common rejection trigger)
+
+---
+
+### Sample Messages
+
+Include **six** sample messages, representing every message type the customer may receive in a typical order. Each identifies the sender and includes opt-out language.
+
+**Sample 1 — Payment Link (sent after order is finalized on the call)**
+> {{Restaurant_Name}}: Your order is ready to pay. Total: $24.80. Tap to pay securely with Stripe: https://pay.dialtone.menu/a4821k9. Link expires in 20 min. Reply STOP to opt out.
+
+**Sample 2 — Payment Confirmation (sent after Stripe webhook fires)**
+> {{Restaurant_Name}}: Payment confirmed, thank you! Order #A4821. 1x Margherita Pizza, 1x Caesar Salad. Ready for pickup around 6:45 PM. Reply STOP to opt out.
+
+**Sample 3 — Order Ready (sent when restaurant marks order complete)**
+> {{Restaurant_Name}}: Your order #A4821 is ready for pickup. See you soon! Questions? Call (555) 123-4567. Reply STOP to opt out.
+
+**Sample 4 — Reservation Confirmation (v1.1, reservation flow)**
+> {{Restaurant_Name}}: Reservation confirmed for Fri Apr 24 at 7:00 PM for 4 guests. Reply CANCEL to cancel or call (555) 123-4567. Reply STOP to opt out.
+
+**Sample 5 — Promotional (only on Marketing add-on, only to promotional-opted-in customers)**
+> {{Restaurant_Name}}: Happy Friday! 15% off any pasta entrée tonight with code PASTA15. Order at {{short_link}}. Reply STOP to opt out.
+
+**Sample 6 — HELP Response (required, often omitted)**
+> {{Restaurant_Name}}: For help with your order, call (555) 123-4567 or email hello@{{restaurant_domain}}. Msg & data rates may apply. Reply STOP to cancel.
+
+**Why these work:**
+
+- Every sample begins with the brand name
+- Every sample ends with STOP language
+- **Sample 1 explicitly shows the payment link use case and shows the short-link domain (pay.dialtone.menu)** — reviewers scrutinize links heavily, and a branded domain passes scrutiny better than a raw stripe.com URL
+- Sample 1 includes a link expiry time — shows you've thought about the security posture
+- Sample 2 is the confirmation-after-payment (not an opt-in confirmation) — this distinction matters: the opt-in already happened verbally
+- Sample 3 uses a concrete order number and contact fallback
+- Sample 4 covers reservations separately
+- Sample 5 is clearly promotional and clearly gated
+- Sample 6 handles HELP — frequently omitted and frequently rejected for that reason
+
+---
+
+### Embedded Links
+
+**Yes.** Transactional messages contain a Stripe Checkout link, typically via a branded short domain (`pay.dialtone.menu/...`) that redirects to `checkout.stripe.com`. Promotional messages may contain a link to {{Restaurant_Website_URL}} or a branded short link.
+
+**Domain disclosure:** Short-link redirects are served from `pay.dialtone.menu` (operated by ByteStreams LLC). The final destination for payment links is always `checkout.stripe.com`. This can be verified by the reviewer.
+
+---
+
+### Embedded Phone Numbers
+
+**Yes.** HELP responses and some transactional messages include the restaurant's customer service phone number.
+
+---
+
+### Age-Gated Content
+
+**No** for food-only restaurants. **Yes** for restaurants selling alcohol — see separate note in the "If Alcohol is Sold" section at the bottom of this document.
+
+---
+
+### Number Pooling
+
+**No.** Each restaurant Brand is assigned a dedicated 10DLC number. Numbers are not shared across restaurants.
+
+---
+
+### Direct Lending Arrangement
+
+**No.**
+
+---
+
+### Subscriber Opt-In
+
+**Yes** — as described in the Call-to-Action section above.
+
+---
+
+### Subscriber Opt-Out
+
+**Yes.** Customers may reply STOP, END, CANCEL, UNSUBSCRIBE, or QUIT at any time. DialTone's platform automatically processes opt-out requests and sends a final confirmation:
+
+> {{Restaurant_Name}}: You've opted out and will no longer receive messages. To re-subscribe, reply START.
+
+**Important:** An opt-out after a payment link has been sent but before payment has been completed triggers a phone call from restaurant staff to resolve the in-flight order. This is logged and disclosed in the SMS Terms page.
+
+---
+
+### Subscriber Help
+
+**Yes.** Customers may reply HELP or INFO at any time and receive the HELP response (Sample 6 above).
+
+---
+
+## Critical Flow Details to Disclose When Asked
+
+Reviewers sometimes ask follow-up questions before approving. Pre-drafted answers to the most likely ones:
+
+**Q: What happens if the customer doesn't pay the payment link?**
+The order stays in `pending_payment` status for 20 minutes, then automatically cancels. No further SMS messages are sent. If the customer wanted to complete the order, they can call back.
+
+**Q: What happens if the payment link SMS doesn't deliver?**
+DialTone detects delivery failures via Twilio's status callbacks. If the payment link fails to deliver, the voice agent will (during the same call, if still connected) inform the customer and offer to transfer to restaurant staff. If the call has already ended, the order is marked as failed and no further action is taken.
+
+**Q: Can someone other than the caller pay the payment link?**
+Technically yes — anyone with access to the text message can tap the link. This is a known limitation of SMS-based payment links across the industry. Stripe Checkout itself handles payment authentication, so the risk is limited to misuse of a phone with the recipient's knowledge. This is disclosed in the SMS Terms page.
+
+**Q: Does the restaurant owner receive any SMS?**
+No. Restaurant owners and staff interact with the DialTone admin dashboard (web-based) to receive new order notifications, manage orders, and update the menu. SMS is strictly consumer-facing.
+
+**Q: How is caller consent different from website consent in terms of proof?**
+Voice consent is proven by (a) the call recording, (b) a transcript with the consent moment timestamped and highlighted, (c) a consent record in the database with the `call_id` and `consent_language_version` fields. Website consent is proven by (a) the form submission log including the IP address, user agent, and timestamp, (b) a record of the exact consent language shown at the time of submission.
+
+---
+
+## Required Website Elements (for each restaurant Brand)
+
+For the reviewer to approve each restaurant's campaign, the restaurant's website must have:
+
+1. **A working HTTPS site at the URL listed on the Brand registration.** Reviewer will visit and verify.
+
+2. **A Privacy Policy** at `/privacy` or `/privacy-policy` that includes:
+   - A section covering SMS/text messaging specifically
+   - Explicit statement that SMS opt-in data is **not shared with third parties for marketing or promotional purposes**
+   - Contact information
+
+3. **An SMS Terms page** at `/sms-terms` (linked from the consent checkbox and from the site footer) that covers:
+   - Who is sending (brand name)
+   - What messages will be sent (payment link, confirmations, order status, optional promotional)
+   - Message frequency
+   - "Message and data rates may apply"
+   - How to opt out (Reply STOP)
+   - How to get help (Reply HELP)
+   - The platform provider (ByteStreams / DialTone)
+   - Contact info
+
+4. **The online ordering page** with the exact consent checkboxes quoted above. Both unchecked by default. Privacy Policy and SMS Terms links present near the checkboxes.
+
+If any of these four elements is missing or the URLs don't resolve, the campaign will be rejected regardless of how good the submission text is.
+
+---
+
+## Platform-Level Requirements (for bytestreams.ai)
+
+Because ByteStreams LLC is registering as the CSP (platform) supporting multiple restaurant Brands, the ByteStreams site must have:
+
+1. A **Privacy Policy** covering the platform's role as a data processor
+2. An **SMS Terms page** at `bytestreams.ai/sms-terms` explaining the platform's role in message delivery, the exact voice consent script, and the payment link flow
+3. An **About page** that clearly identifies ByteStreams LLC, its EIN, registered address (Nashville, TN), and business purpose
+4. A **sub-processor list** at a predictable URL (Twilio, Vapi, ElevenLabs, Supabase, Cloudflare, Stripe)
+5. **Contact information** — `hello@bytestreams.ai` and `629-282-9555`
+
+The reviewer will verify that the business is real and that the EIN on the Brand registration matches IRS records for "ByteStreams LLC" (or whatever the exact legal name is on the SS-4 — verify before submitting).
+
+---
+
+## If Alcohol is Sold
+
+Restaurants that serve beer, wine, or cocktails require additional compliance:
+
+- The online ordering flow must require **manual entry of date of birth (MM/DD/YYYY)** before the customer can see or order alcohol items. "Are you 21?" yes/no toggles do not pass review.
+- Voice ordering of alcohol should either (a) route the customer to a human for ID verification at pickup, or (b) route to staff at the start of the call, bypassing DialTone for alcohol orders entirely.
+- SMS samples should avoid explicit promotion of alcohol unless age-gating is demonstrably implemented on the website.
+- **Recommendation for v1.0:** Exclude alcohol promotion from the Campaign entirely, even for restaurants that serve it. Order confirmations may include alcohol items already ordered, but promotional SMS stays food-only. Alcohol age-verification is better addressed as a v1.1 or v1.2 feature after the base platform has a clean compliance track record.
+
+---
+
+## Resubmission Strategy
+
+Since the first submission was rejected, the resubmission should:
+
+1. **Explicitly address the original rejection reason in the description.** If the rejection cited "insufficient opt-in detail," the new description should visibly resolve that. If it cited "unclear use case," the new description's structure should demonstrate exactly why the payment link SMS is needed.
+
+2. **Not submit until every referenced URL resolves.** `{{Restaurant_Website_URL}}/privacy`, `/sms-terms`, and `/order` must all be live HTTPS pages with real content. Reviewers test them.
+
+3. **Use a business email for the Brand admin.** `hello@bytestreams.ai` — not Gmail, Yahoo, or a personal address. Generic email domains are a documented rejection trigger.
+
+4. **Verify legal entity name consistency.** "ByteStreams LLC" on the Brand form must match exactly what's on the IRS EIN letter, the SS-4, the Articles of Organization, and the website footer. Small capitalization differences ("Bytestreams" vs "ByteStreams") are flagged by automated review tools.
+
+5. **Register ByteStreams itself as a Brand first, before any restaurant.** Get a platform-level Brand approved with a simple, low-stakes internal campaign (for example, DialTone's own signup confirmations to onboarding restaurants). Once that's approved and clean for 30 days, restaurant Brands benefit from your established CSP track record.
+
+6. **Keep records of every consent event.** Reviewers may audit after approval. For voice consent, retain the call recording, the transcript with the consent moment highlighted, and the database record linking them.
+
+---
+
+## Fields to Fill Before Submitting
+
+Anywhere you see `{{ double_braces }}` in this document, replace with the actual value. Before clicking submit, ctrl-F for `{{` to verify nothing slipped through. A submission containing literal `{{Restaurant_Name}}` is an instant rejection.

--- a/docs/bytestreams-sms-terms.html
+++ b/docs/bytestreams-sms-terms.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>SMS Terms &amp; Consent · ByteStreams LLC</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,500;0,9..144,700;1,9..144,500&family=JetBrains+Mono:wght@400;500&family=Instrument+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --ink: #1a1410;
+    --paper: #f5efe6;
+    --paper-warm: #ebe3d5;
+    --accent: #c8391a;
+    --muted: #6b5d4f;
+    --line: #2a211a;
+    --gold: #b89968;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  html, body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: 'Instrument Sans', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    line-height: 1.6;
+  }
+
+  .container {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+
+  /* NAV */
+  nav {
+    border-bottom: 1px solid var(--line);
+    padding: 1.25rem 0;
+    background: var(--paper);
+  }
+  nav .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    max-width: 1240px;
+  }
+  .logo {
+    font-family: 'Fraunces', serif;
+    font-weight: 700;
+    font-size: 1.35rem;
+    letter-spacing: -0.02em;
+    display: flex;
+    align-items: baseline;
+  }
+  .logo::before {
+    content: "●";
+    color: var(--accent);
+    font-size: 0.7em;
+    margin-right: 0.4rem;
+  }
+  .nav-meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.15em;
+    color: var(--muted);
+    text-transform: uppercase;
+  }
+
+  /* HEADER */
+  .doc-header {
+    padding: 4rem 0 3rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .eyebrow {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
+    color: var(--accent);
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+  }
+  h1 {
+    font-family: 'Fraunces', serif;
+    font-weight: 400;
+    font-size: clamp(2.2rem, 4.5vw, 3.5rem);
+    line-height: 1.05;
+    letter-spacing: -0.03em;
+    margin-bottom: 1.25rem;
+  }
+  h1 em {
+    font-style: italic;
+    color: var(--accent);
+  }
+  .doc-meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    text-transform: uppercase;
+    margin-top: 1rem;
+  }
+  .summary-box {
+    margin-top: 2rem;
+    padding: 1.5rem 1.75rem;
+    background: var(--paper-warm);
+    border-left: 3px solid var(--accent);
+  }
+  .summary-box p {
+    font-size: 0.97rem;
+    color: var(--ink);
+    margin: 0;
+  }
+
+  /* CONTENT */
+  main {
+    padding: 3rem 0 5rem;
+  }
+
+  h2 {
+    font-family: 'Fraunces', serif;
+    font-weight: 500;
+    font-size: 1.7rem;
+    letter-spacing: -0.02em;
+    margin: 3rem 0 1rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid rgba(26, 20, 16, 0.15);
+  }
+  h2:first-of-type { border-top: none; padding-top: 0; margin-top: 0; }
+  h2 .num {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--accent);
+    margin-right: 0.7rem;
+    letter-spacing: 0.1em;
+    vertical-align: middle;
+  }
+
+  h3 {
+    font-family: 'Fraunces', serif;
+    font-weight: 500;
+    font-size: 1.15rem;
+    margin: 1.75rem 0 0.75rem;
+    letter-spacing: -0.01em;
+  }
+
+  p {
+    font-size: 0.98rem;
+    margin-bottom: 1.1rem;
+    color: var(--ink);
+  }
+
+  ul, ol {
+    margin: 0 0 1.1rem 1.5rem;
+  }
+  li {
+    font-size: 0.98rem;
+    margin-bottom: 0.5rem;
+  }
+  ul li::marker {
+    color: var(--accent);
+  }
+
+  strong { font-weight: 600; }
+
+  a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+  a:hover { color: var(--ink); }
+
+  code, .kbd {
+    font-family: 'JetBrains Mono', monospace;
+    background: var(--paper-warm);
+    padding: 0.1rem 0.4rem;
+    font-size: 0.88em;
+    border-radius: 2px;
+  }
+
+  .callout {
+    padding: 1.25rem 1.5rem;
+    background: var(--ink);
+    color: var(--paper);
+    margin: 1.5rem 0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.87rem;
+    line-height: 1.6;
+  }
+  .callout strong {
+    color: var(--gold);
+    font-family: 'Instrument Sans', sans-serif;
+    font-weight: 600;
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+    font-size: 0.92rem;
+  }
+  th, td {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(26, 20, 16, 0.15);
+  }
+  th {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--muted);
+    border-bottom: 2px solid var(--line);
+  }
+
+  /* FOOTER */
+  footer {
+    padding: 2rem 0;
+    background: var(--ink);
+    color: rgba(245, 239, 230, 0.55);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+  }
+  footer .container {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    max-width: 1240px;
+  }
+  footer a {
+    color: rgba(245, 239, 230, 0.8);
+    text-decoration: none;
+  }
+  footer a:hover { color: var(--gold); }
+
+  @media (max-width: 640px) {
+    h1 { font-size: 2rem; }
+    .doc-header { padding: 2.5rem 0 2rem; }
+    footer .container { flex-direction: column; align-items: flex-start; }
+  }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="container">
+    <div class="logo">ByteStreams</div>
+    <div class="nav-meta">Compliance · SMS Terms</div>
+  </div>
+</nav>
+
+<header class="doc-header">
+  <div class="container">
+    <div class="eyebrow">SMS Text Messaging Terms &amp; Consent</div>
+    <h1>How our platform <em>handles text messaging.</em></h1>
+    <div class="doc-meta">Effective April 22, 2026 · ByteStreams LLC · 10DLC Compliant</div>
+    <div class="summary-box">
+      <p>ByteStreams LLC operates DialTone, an AI voice ordering platform. When you place an order through DialTone's voice agent, we send you a Stripe payment link via SMS to complete your purchase, followed by a confirmation and an order-ready update. The restaurant you ordered from is the sender of these messages; ByteStreams is the platform that delivers them. This page explains how consent is obtained, what messages you'll receive, and how to stop them at any time.</p>
+    </div>
+  </div>
+</header>
+
+<main>
+  <div class="container">
+
+    <h2><span class="num">01</span>About ByteStreams and DialTone</h2>
+    <p>ByteStreams LLC is a Tennessee-registered limited liability company. We operate DialTone, an AI voice ordering platform used by restaurants to answer inbound customer calls and take orders. When a restaurant using DialTone sends you an SMS message, the restaurant is the sender of record. ByteStreams acts as the Communication Service Provider (CSP) that delivers the message through registered 10DLC infrastructure.</p>
+    <p>You can reach us at:</p>
+    <ul>
+      <li><strong>ByteStreams LLC</strong> · 501 Union St Ste 545, Nashville, TN 37219</li>
+      <li>Email: <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a></li>
+      <li>Phone: <a href="tel:+16292829555">629-282-9555</a></li>
+    </ul>
+
+    <h2><span class="num">02</span>Consent &mdash; How You Opt In</h2>
+    <p>You will only receive SMS messages from a restaurant using DialTone if you have provided express consent through one of the following channels:</p>
+
+    <h3>Voice consent during a phone order</h3>
+    <p>When you call a restaurant that uses DialTone, our AI voice agent captures your SMS consent at the start of the call, before taking your order. This is because completing your order requires us to text you a Stripe payment link, and we won't take your order unless we have permission to send that text. The exact language the agent uses is:</p>
+    <div class="callout">
+      <strong>Agent Script · Voice Consent</strong>
+      "Thanks for calling [Restaurant Name]! I can take your order right now. Just so you know, to finish your order I'll need to text you a payment link from Stripe, and I'll also text you a confirmation when payment clears and another text when your order is ready. Message and data rates may apply, and you can reply STOP anytime to unsubscribe. Is it OK to text you at the number you're calling from?"
+    </div>
+    <p>If you say yes, the agent will read back the last four digits of the number you're calling from (or a different number if you provide one) and confirm it's the right number for texts before proceeding. Your verbal consent is recorded, time-stamped, and retained as proof of opt-in.</p>
+    <p>If you say no, the agent will politely transfer you to restaurant staff so they can take your order directly. No SMS messages will be sent and no consent record will be created.</p>
+
+    <h3>Website consent during online ordering</h3>
+    <p>When you place an order on a restaurant's website that uses DialTone, you may see two consent checkboxes. The first is required to place the order (because we need to text you a payment link); the second is optional:</p>
+    <div class="callout">
+      <strong>Required Checkbox · Transactional</strong>
+      "Yes, text me a Stripe payment link, order confirmation, and pickup/delivery updates from [Restaurant Name]. Message frequency varies. Message and data rates may apply. Reply STOP to unsubscribe. See our Privacy Policy and SMS Terms."
+    </div>
+    <div class="callout">
+      <strong>Optional Checkbox · Promotional</strong>
+      "Also text me occasional offers from [Restaurant Name], up to 2 per month. Reply STOP to unsubscribe."
+    </div>
+    <p>Both checkboxes are unchecked by default. You must affirmatively check the required checkbox to place the order. The promotional checkbox is entirely optional and can be left unchecked. No pre-checked boxes, no opt-in bundled into unrelated agreements.</p>
+
+    <h2><span class="num">03</span>What Messages You'll Receive</h2>
+    <p>Opted-in customers may receive the following message types from the restaurant:</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Type</th>
+          <th>Purpose</th>
+          <th>Frequency</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Payment link</td>
+          <td>A secure Stripe payment link to complete your order</td>
+          <td>1 per order</td>
+        </tr>
+        <tr>
+          <td>Payment confirmation</td>
+          <td>Confirms your payment cleared and recaps the order</td>
+          <td>1 per order</td>
+        </tr>
+        <tr>
+          <td>Order ready / status update</td>
+          <td>Notifies you when your order is ready for pickup or out for delivery</td>
+          <td>1&ndash;2 per order</td>
+        </tr>
+        <tr>
+          <td>Reservation reminder</td>
+          <td>Reminds you of an upcoming reservation (where supported)</td>
+          <td>1 per reservation</td>
+        </tr>
+        <tr>
+          <td>Promotional</td>
+          <td>Occasional offers or menu updates (only if you opted in to promotional messages)</td>
+          <td>Up to 2 per month</td>
+        </tr>
+        <tr>
+          <td>HELP response</td>
+          <td>Sent in reply to your HELP request</td>
+          <td>As requested</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>Transactional messages (payment link, payment confirmation, order ready) are required to complete a voice order. If you decline consent during the call, the agent will transfer you to restaurant staff so your order can be taken directly — no SMS messages will be sent. Promotional messages are always optional and separately opted-in.</p>
+
+    <h2><span class="num">04</span>Message and Data Rates</h2>
+    <p>Message and data rates may apply, depending on your mobile plan and carrier. ByteStreams and the restaurant do not charge you for SMS messages; however, your wireless carrier may. Please check your plan for details.</p>
+
+    <h2><span class="num">05</span>How to Stop Receiving Messages</h2>
+    <p>You can opt out at any time by replying any of the following keywords to any message:</p>
+    <ul>
+      <li><code>STOP</code></li>
+      <li><code>END</code></li>
+      <li><code>CANCEL</code></li>
+      <li><code>UNSUBSCRIBE</code></li>
+      <li><code>QUIT</code></li>
+    </ul>
+    <p>Once you opt out, you will receive one final confirmation message:</p>
+    <div class="callout">
+      <strong>Opt-Out Confirmation</strong>
+      "[Restaurant Name]: You've opted out and will no longer receive messages. To re-subscribe, reply START."
+    </div>
+    <p>You will not receive further messages from that restaurant unless you explicitly opt back in. Opt-outs are processed immediately and automatically by DialTone's platform.</p>
+
+    <h2><span class="num">06</span>How to Get Help</h2>
+    <p>Reply <code>HELP</code> or <code>INFO</code> to any message to receive the restaurant's support contact information. You can also contact ByteStreams directly at <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a> or <a href="tel:+16292829555">629-282-9555</a> if you have questions about the messaging platform itself.</p>
+
+    <h2><span class="num">07</span>Supported Carriers</h2>
+    <p>DialTone messages are sent through registered 10DLC infrastructure and are supported on all major U.S. wireless carriers including AT&amp;T, T-Mobile, Verizon, and their subsidiaries and MVNOs. Carriers are not liable for delayed or undelivered messages.</p>
+
+    <h2><span class="num">08</span>Privacy and Data Sharing</h2>
+    <p>SMS opt-in data (including your phone number and the fact that you consented to receive messages) is <strong>not shared with third parties for marketing or promotional purposes</strong>. Specifically:</p>
+    <ul>
+      <li>We do not sell your phone number.</li>
+      <li>We do not share your phone number with marketing partners, data brokers, or affiliates for their own marketing use.</li>
+      <li>We share your phone number only with service providers necessary to deliver messages (such as Twilio and The Campaign Registry) and with the specific restaurant you gave consent to.</li>
+    </ul>
+    <p>For full details on how we handle personal data, see our <a href="/privacy">Privacy Policy</a>.</p>
+
+    <h2><span class="num">09</span>Eligibility</h2>
+    <p>SMS messaging through DialTone is intended for recipients who are at least 18 years old, or who are old enough to consent to receive commercial SMS messages under applicable state law. If you are a minor, please do not provide your phone number or consent to receive messages without the involvement of a parent or guardian.</p>
+
+    <h2><span class="num">10</span>Recording and Retention</h2>
+    <p>Voice consents are recorded and retained as proof of opt-in. Consent records are kept for a minimum of four (4) years after the most recent message sent to the opted-in number, or longer if required by applicable law. Website consents are logged with timestamp, IP address, and the exact consent language displayed at the time of opt-in.</p>
+
+    <h2><span class="num">11</span>Restaurants Using DialTone</h2>
+    <p>If you are a restaurant using DialTone, your obligations around SMS consent are governed by the DialTone Terms of Service and the Data Processing Addendum available to you through your DialTone account. In summary: you are the sender of messages to your customers, and you are responsible for ensuring that every customer you message has provided valid consent. ByteStreams provides the infrastructure and consent-capture tools; the restaurant provides the relationship with its customers.</p>
+
+    <h2><span class="num">12</span>Updates to These Terms</h2>
+    <p>We may update these SMS Terms from time to time to reflect changes in our practices, technology, legal requirements, or carrier rules. The effective date at the top of this page will be updated when we do. Continued use of the messaging service after the effective date constitutes acceptance.</p>
+
+    <h2><span class="num">13</span>Contact</h2>
+    <p>Questions about these terms, your consent, or a message you received can be directed to:</p>
+    <ul>
+      <li><strong>ByteStreams LLC</strong></li>
+      <li>501 Union St Ste 545, Nashville, TN 37219</li>
+      <li>Email: <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a></li>
+      <li>Phone: <a href="tel:+16292829555">629-282-9555</a></li>
+    </ul>
+
+  </div>
+</main>
+
+<footer>
+  <div class="container">
+    <div>© 2026 BYTESTREAMS LLC · NASHVILLE, TN</div>
+    <div>
+      <a href="/privacy">Privacy</a> &nbsp;·&nbsp;
+      <a href="/terms">Terms</a> &nbsp;·&nbsp;
+      <a href="/sms-terms">SMS Terms</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/coookie-policy.md
+++ b/docs/coookie-policy.md
@@ -1,0 +1,68 @@
+
+# COOKIE POLICY
+
+**Last updated April 21, 2026**
+
+This Cookie Policy explains how bytestreams (**"Company"**, **"we"**, **"us"**, and **"our"**) uses cookies and similar technologies to recognize you when you visit our website at [https://bytestreams.ai](https://bytestreams.ai) (**"Website"**). It explains what these technologies are and why we use them, as well as your rights to control our use of them.
+
+In some cases we may use cookies to collect personal information, or that becomes personal information if we combine it with other information.
+
+## What are cookies?
+
+Cookies are small data files that are placed on your computer or mobile device when you visit a website. Cookies are widely used by website owners in order to make their websites work, or to work more efficiently, as well as to provide reporting information.
+
+Cookies set by the website owner (in this case, bytestreams) are called "first-party cookies." Cookies set by parties other than the website owner are called "third-party cookies." Third-party cookies enable third-party features or functionality to be provided on or through the website (e.g., advertising, interactive content, and analytics). The parties that set these third-party cookies can recognize your computer both when it visits the website in question and also when it visits certain other websites.
+
+## Why do we use cookies?
+
+We use first- and third-party cookies for several reasons. Some cookies are required for technical reasons in order for our Website to operate, and we refer to these as "essential" or "strictly necessary" cookies. Other cookies also enable us to track and target the interests of our users to enhance the experience on our Online Properties. Third parties serve cookies through our Website for advertising, analytics, and other purposes. This is described in more detail below.
+
+## How can I control cookies on my browser?
+
+As the means by which you can refuse cookies through your web browser controls vary from browser to browser, you should visit your browser's help menu for more information. The following is information about how to manage cookies on the most popular browsers:
+
+- [Chrome](https://support.google.com/chrome/answer/95647)
+- [Firefox](https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer)
+- [Safari](https://support.apple.com/guide/safari/manage-cookies-sfri11471/mac)
+- [Edge](https://support.microsoft.com/en-us/microsoft-edge/delete-cookies-in-microsoft-edge-63947406-40ac-c3b8-57b9-2a946a29ae09)
+- [Opera](https://help.opera.com/en/latest/web-preferences/)
+- [Digital Advertising Alliance](https://www.youradchoices.com/)
+- [DAA Canada](https://youradchoices.ca/)
+- [EDAA](https://www.youronlinechoices.eu/)
+
+In addition, most advertising networks offer you a way to opt out of targeted advertising. If you would like to find out more information, please visit:
+
+- Digital Advertising Alliance
+- Digital Advertising Alliance of Canada
+- European Interactive Digital Advertising Alliance
+
+## What about other tracking technologies, like web beacons?
+
+Cookies are not the only way to recognize or track visitors to a website. We may use other, similar technologies from time to time, like web beacons (sometimes called "tracking pixels" or "clear gifs"). These are tiny graphics files that contain a unique identifier that enables us to recognize when someone has visited our Website or opened an email including them. This allows us, for example, to monitor the traffic patterns of users from one page within a website to another, to deliver or communicate with cookies, to understand whether you have come to the website from an online advertisement displayed on a third-party website, to improve site performance, and to measure the success of email marketing campaigns. In many instances, these technologies are reliant on cookies to function properly, and so declining cookies will impair their functioning.
+
+## Do you use Flash cookies or Local Shared Objects?
+
+Websites may also use so-called "Flash Cookies" (also known as Local Shared Objects or "LSOs") to, among other things, collect and store information about your use of our services, fraud prevention, and for other site operations.
+
+If you do not want Flash Cookies stored on your computer, you can adjust the settings of your Flash player to block Flash Cookies storage using the tools contained in the [Website Storage Settings Panel](https://www.macromedia.com/support/documentation/en/flashplayer/help/settings_manager07.html). You can also control Flash Cookies by going to the [Global Storage Settings Panel](https://www.macromedia.com/support/documentation/en/flashplayer/help/settings_manager03.html) and following the instructions (which may include instructions that explain, for example, how to delete existing Flash Cookies (referred to "information" on the Macromedia site), how to prevent Flash LSOs from being placed on your computer without your being asked, and (for Flash Player 8 and later) how to block Flash Cookies that are not being delivered by the operator of the page you are on at the time).
+
+Please note that setting the Flash Player to restrict or limit acceptance of Flash Cookies may reduce or impede the functionality of some Flash applications, including, potentially, Flash applications used in connection with our services or online content.
+
+## Do you serve targeted advertising?
+
+Third parties may serve cookies on your computer or mobile device to serve advertising through our Website. These companies may use information about your visits to this and other websites in order to provide relevant advertisements about goods and services that you may be interested in. They may also employ technology that is used to measure the effectiveness of advertisements. They can accomplish this by using cookies or web beacons to collect information about your visits to this and other sites in order to provide relevant advertisements about goods and services of potential interest to you. The information collected through this process does not enable us or them to identify your name, contact details, or other details that directly identify you unless you choose to provide these.
+
+## How often will you update this Cookie Policy?
+
+We may update this Cookie Policy from time to time in order to reflect, for example, changes to the cookies we use or for other operational, legal, or regulatory reasons. Please therefore revisit this Cookie Policy regularly to stay informed about our use of cookies and related technologies.
+The date at the top of this Cookie Policy indicates when it was last updated.
+
+## Where can I get further information?
+
+If you have any questions about our use of cookies or other technologies, please email us at [hello@bytestreams.ai](mailto:hello@bytestreams.ai) or by post to:
+
+ByteStreams
+501 Union St
+Nashville, TN 38219
+United States
+Phone; +1 629 282 9555

--- a/docs/privacy-notice.md
+++ b/docs/privacy-notice.md
@@ -1,0 +1,212 @@
+
+# PRIVACY NOTICE
+
+**Last Update 21 April 2026**
+
+The Privacy Notice for bytestreams LLC (**"we"**, **"us"**, or **"our"**), describes how and why we might access,
+collect, store, use, and/or share ("process") your personal information when you use our services ("Services"), 
+including when you:
+**Questions or concerns ?** Reading this Privacy Notice will help you understand your privacy rights and choices.
+We are responsible for making decisions about how your personal information is processed. If you do not agree with 
+our policies and practices, please do use our Services. 
+
+## SUMMARY OF KEY POINTS
+
+This summary provides key points from our Privacy Notice, but you can find out more details about any of these topics
+by clicking the link following each key point or by using our `table of contents` below to find the section you are
+looking for. 
+
+**What personal information do we process ?** When you visit, use, or navigate our Services, we may process 
+personal information depending on how you interact with us and our services, the choices you make, the products
+and features you use. Learn more about `personal information you disclose to us.`
+
+**Do we process any sensitive personal information ?** Some of the information may be considered "special" or 
+"sensitive" in certain jurisdictions, for example your racial or ethnic origins, sexual orientation, and religious beliefs.
+We do not process sensitive personal information.
+
+**Do we collect any information from third parties ?"** We do not collect any information from public databases
+, marketing partners, social media platforms, and other outside sources. Learn more about `information collected`
+`from other sources.`
+
+**How do we process your information ?** We process your information to provide, improve, and administer our
+Services, communicate with you, for security and fraud prevention, and to comply with law. We may also process 
+your information for other purposes with your consent. We process your information only when we have a valid 
+legal reason to do so. Learn more about `how we process your information`
+
+**What are your rights ?** Depending on where you are located geographically, the applicable privacy law may
+may mean you have certain rights regarding your personal information. Learn more about `your privacy rights`
+
+**How do you exercise your rights?** The easiest way to exercise your rights is by submitting a `data subject`
+`access request`, or by contacting us. We will consider and act upon any request in accordance with applicable
+data protection laws.
+
+Want to learn more about what we do with any information we collect? `Review the Privacy Notice in full.`
+
+## TABLE OF CONTENTS
+
+1. [WHAT INFORMATION DO WE COLLECT?](#1-what-information-do-we-collect)
+2. [HOW DO WE PROCESS YOUR INFORMATION?](#2-how-dowe-process-your-information)
+3. [WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?](#3-when-and-with-whom-do-we-share-your-personal-information)
+4. [DO WE USE COOKIES AND OTHER TRACKING TECHNOLOGIES?](#4-do-we-use-cookies-and-other-tracking-technologies)
+5. [HOW DO WE HANDLE YOUR SOCIAL LOGINS?](#5-how-do-we-handle-your-social-logins)
+6. [IS YOUR INFORMATION TRANSFERRED INTERNATIONALLY?](#6-is-your-information-transferred-internationally)
+7. [HOW LONG DO WE KEEP YOUR INFORMATION?](#7-how-long-do-we-keep-your-information)
+8. [DO WE COLLECT INFORMATION FROM MINORS?](#8-do-we-collect-information-from-minors)
+9. [WHAT ARE YOUR PRIVACY RIGHTS?](#9-what-are-your-privacy-rights)
+10. [CONTROLS FOR DO-NOT-TRACK FEATURES](#10-controls-for-do-not-track-features)
+11. [DO WE MAKE UPDATES TO THIS NOTICE?](#11-do-we-make-updates-to-this-notice)
+12. [HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](#12-how-can-you-contact-us-about-this-notice)
+13. [HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?](#13-how-can-you-review-update-or-delete-the-data-we-collect-from-you)
+
+## 1. WHAT INFORMATION DO WE COLLECT?
+
+### Personal Information you disclose to us
+
+In Short: ***We collect personal information that you provide us.***
+
+We collect personal information that you voluntarily provide us when your accept our request for data which is
+used to provide our Services. when you participate in activities on the Services, or otherwise when you contact
+us. 
+
+**Sensitive Information.** We do not process sensitive information
+
+All personal information that you provide to us must be true, complete, and accurate, and you must notify us of
+any changes to such personal  information.
+
+## 2. HOW DOWE PROCESS YOUR INFORMATION? 
+
+In short: We process your information to provide, improve, and administer our Services, communicate with you,
+for security and fraud prevention, and to comply with law.We may also process your information for other purposes
+with your consent.
+
+**We process your personal information for a variety of reasons, depending on how you interact with our**
+**Services, including:**
+
+## 3. WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?
+
+In Short: ***We may share information in specific situations described in this section and/or with the***
+***the following third parties**
+
+We may need to share your personal information in the following situations:
+
+- ***Business Transfers.*** We may hare or transfer your information in connection with, or during negotiations of,
+any merger, sale of company assets, financing, or acquisition of all or a portion of our business to another company.
+
+- ***Affiliates.*** We may share your information with our affiliates, in which case we will require those affiliates to
+honor this Privacy Notice. Affiliates include our parent company and any subsidiaries, joint  venture partners, or
+other companies that we control or that are under common control with us.
+
+- ***Business Partners.*** We may share your information with our business partners to offer your certain products,
+services, or promotions
+
+## 4. DO WE USE COOKIES AND OTHER TRACKING TECHNOLOGIES.
+
+In Short; No. None of your services are web bases. All of our customer facing traffic is via SMS. Visitors to our web
+site can only submit contact information via email and no cookie technologies are used.
+
+Specific information about how we use such technologies can be found in our Cookie Notice.
+
+## 5. HOW DO WE HANDLE YOUR SOCIAL LOGINS?
+
+In Short: ***If you choose to register or log in to our Services using a social media account, we may have access to certain information about you.***
+
+Our Services may offer you the ability to register and log in using your third-party social media account details. 
+If you choose to register or log in using a social media account, we will access certain information that your social media 
+provider has made available to us in accordance with their terms of service and your privacy settings on that platform.
+
+We will not be responsible for the handling of your information by third-party social media providers. We encourage you 
+to review their privacy notices and contact them directly regarding their information practices.
+
+## 6. IS YOUR INFORMATION TRANSFERRED INTERNATIONALLY?
+
+In Short: ***If you are accessing our Services from outside the United States, please be aware that your information may be transferred to, stored in, and processed in countries other than your country of residence.***
+
+Our servers are located in the United States. If you are accessing our Services from outside the United States, please 
+be aware that your information may be transferred to, stored in, and processed by us in our facilities and by those third 
+parties with whom we may share your personal information in the United States and other countries.
+
+If you are a resident of the European Union, United Kingdom, or other regions with laws governing data collection and use 
+that may differ from U.S. law, please note that we transfer information to a country and jurisdiction that may not have 
+the same data protection laws as your jurisdiction.
+
+## 7. HOW LONG DO WE KEEP YOUR INFORMATION?
+
+In Short: ***We keep your information for as long as necessary to fulfill the purposes outlined in this Privacy Notice unless a longer retention period is required or permitted by law.***
+
+We will only keep your personal information for as long as it is necessary for the purposes set out in this Privacy Notice, 
+unless a longer retention period is required or permitted by law. No purpose in this notice will require us keeping your 
+personal information for longer than the period of time in which users have an account with us.
+
+When you delete your account, we will delete or anonymize your personal information, except where we are required by law 
+to retain such information.
+
+## 8. DO WE COLLECT INFORMATION FROM MINORS?
+
+In Short: ***We do not knowingly collect data from or market to children under 18 years of age.***
+
+We do not knowingly solicit data from or market to children under 18 years of age. By using our Services, you represent 
+that you are at least 18 years of age and possess the legal authority to enter into these terms. If we learn that personal 
+information from users less than 18 years of age has been collected, we will deactivate the account and take reasonable 
+efforts to promptly remove such data from our records.
+
+## 9. WHAT ARE YOUR PRIVACY RIGHTS?
+
+In Short: ***In some regions, such as the European Union, you have rights that allow you greater access to and control over your personal information. You may have the right to access, correct, delete, or port your information.***
+
+Depending on your location, you may have the following rights:
+
+- ***Right to Access:*** You have the right to request access to the personal information we have collected from you.
+- ***Right to Correction:*** You have the right to request that we correct inaccurate or incomplete information.
+- ***Right to Deletion:*** You have the right to request deletion of your personal information, subject to certain exceptions.
+- ***Right to Data Portability:*** You have the right to request a copy of your information in a portable format.
+- ***Right to Withdraw Consent:*** Where we rely on your consent to process your information, you have the right to withdraw that consent.
+- ***Right to Object:*** You have the right to object to the processing of your personal information.
+
+To exercise any of these rights, please submit a data subject access request to us using the contact information below.
+
+## 10. CONTROLS FOR DO-NOT-TRACK FEATURES
+
+Most web browsers and some mobile operating systems and mobile applications include a Do-Not-Track ("DNT") feature or 
+setting you can activate to signal your privacy preference not to have data about your online browsing activities monitored 
+and collected.
+
+At this time, no industry standard has been adopted to recognize or honor DNT signals. However, since we do not use cookies 
+or other tracking technologies as described in Section 4, DNT preferences are not applicable to our Services.
+
+## 11. DO WE MAKE UPDATES TO THIS NOTICE?
+
+In Short: ***Yes, we will update this notice as necessary to stay compliant with relevant laws.***
+
+We may update this Privacy Notice from time to time to reflect changes in our practices, technology, legal requirements, or 
+other factors. If we make material changes to this Privacy Notice, we will notify you by updating the "Last Update" date at 
+the top of this Privacy Notice, and we will take any other steps required by applicable law.
+
+We encourage you to review this Privacy Notice periodically to stay informed about how we protect your information.
+
+## 12. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?
+
+If you have questions or comments about this Privacy Notice, please contact us at:
+
+**bytestreams LLC**
+
+Email: privacy@bytestreams.com
+
+Mailing Address:
+bytestreams LLC
+Privacy Team
+[Company Address]
+
+We will respond to your inquiry within the timeframe required by applicable law, typically within thirty (30) days.
+
+## 13. HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?
+
+In Short: ***You have the right to request access to, correct, or delete your personal information.***
+
+Upon your request, we will provide you with information about whether we hold or process any of your personal information. 
+You may access, correct, update, or request deletion of your personal information by contacting us at the information 
+provided in Section 12.
+
+To protect your privacy and security, we may ask you to verify your identity before responding to your request. We will 
+respond to your request in accordance with applicable data protection laws, typically within thirty (30) days of receipt 
+of your request.
+

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -1,0 +1,288 @@
+# TERMS AND CONDITIONS
+
+**Last updated April 22, 2026**
+
+## AGREEMENT TO OUR LEGAL TERMS
+
+We are bytestreams ("**Company**," "**we**," "**us**," "**our**"), a company registered in Tennessee, United States at 501 Union St Ste 545, Nashville, TN 37219.
+
+We operate the website [https://bytestreams.ai](https://bytestreams.ai) (the "**Site**"), as well as any other related products and services that refer or link to these legal terms (the "**Legal Terms**") (collectively, the "**Services**").
+
+We provide Agentic SaaS solutions and AI/ML Pipelines
+
+You can contact us by phone at 629-282-9555, email at [hello@bytestreams.ai](mailto:hello@bytestreams.ai), or by mail to 501 Union St Ste 545, Nashville, TN 37219, United States.
+
+These Legal Terms constitute a legally binding agreement made between you, whether personally or on behalf of an entity ("**you**"), and bytestreams, concerning your access to and use of the Services. You agree that by accessing the Services, you have read, understood, and agreed to be bound by all of these Legal Terms. IF YOU DO NOT AGREE WITH ALL OF THESE LEGAL TERMS, THEN YOU ARE EXPRESSLY PROHIBITED FROM USING THE SERVICES AND YOU MUST DISCONTINUE USE IMMEDIATELY.
+
+Supplemental terms and conditions or documents that may be posted on the Services from time to time are hereby expressly incorporated herein by reference. We reserve the right, in our sole discretion, to make changes or modifications to these Legal Terms at any time and for any reason. We will alert you about any changes by updating the "Last updated" date of these Legal Terms, and you waive any right to receive specific notice of each such change. It is your responsibility to periodically review these Legal Terms to stay informed of updates. You will be subject to, and will be deemed to have been made aware of and to have accepted, the changes in any revised Legal Terms by your continued use of the Services after the date such revised Legal Terms are posted.
+
+The Services are intended for users who are at least 18 years old. Persons under the age of 18 are not permitted to use or register for the Services.
+
+We recommend that you print a copy of these Legal Terms for your records.
+
+## TABLE OF CONTENTS
+
+1. [OUR SERVICES](#1-our-services)
+2. [INTELLECTUAL PROPERTY RIGHTS](#2-intellectual-property-rights)
+3. [USER REPRESENTATIONS](#3-user-representations)
+4. [PURCHASES AND PAYMENT](#4-purchases-and-payment)
+5. [SUBSCRIPTIONS](#5-subscriptions)
+6. [PROHIBITED ACTIVITIES](#6-prohibited-activities)
+7. [USER GENERATED CONTRIBUTIONS](#7-user-generated-contributions)
+8. [CONTRIBUTION LICENSE](#8-contribution-license)
+9. [THIRD-PARTY WEBSITES AND CONTENT](#9-third-party-websites-and-content)
+10. [SERVICES MANAGEMENT](#10-services-management)
+11. [PRIVACY POLICY](#11-privacy-policy)
+12. [TERM AND TERMINATION](#12-term-and-termination)
+13. [MODIFICATIONS AND INTERRUPTIONS](#13-modifications-and-interruptions)
+14. [GOVERNING LAW](#14-governing-law)
+15. [DISPUTE RESOLUTION](#15-dispute-resolution)
+16. [CORRECTIONS](#16-corrections)
+17. [DISCLAIMER](#17-disclaimer)
+18. [LIMITATIONS OF LIABILITY](#18-limitations-of-liability)
+19. [INDEMNIFICATION](#19-indemnification)
+20. [USER DATA](#20-user-data)
+21. [ELECTRONIC COMMUNICATIONS, TRANSACTIONS, AND SIGNATURES](#21-electronic-communications-transactions-and-signatures)
+22. [SMS TEXT MESSAGING](#22-sms-text-messaging)
+23. [CALIFORNIA USERS AND RESIDENTS](#23-california-users-and-residents)
+24. [MISCELLANEOUS](#24-miscellaneous)
+25. [CONTACT US](#25-contact-us)
+
+## 1. OUR SERVICES
+
+The information provided when using the Services is not intended for distribution to or use by any person or entity in any jurisdiction or country where such distribution or use would be contrary to law or regulation or which would subject us to any registration requirement within such jurisdiction or country. Accordingly, those persons who choose to access the Services from other locations do so on their own initiative and are solely responsible for compliance with local laws, if and to the extent local laws are applicable.
+
+All SMS messaging operated by ByteStreams LLC is 10DLC Compliant
+
+## 2. INTELLECTUAL PROPERTY RIGHTS
+
+### Our intellectual property
+
+We are the owner or the licensee of all intellectual property rights in our Services, including all source code, databases, functionality, software, website designs, audio, video, text, photographs, and graphics in the Services (collectively, the "Content"), as well as the trademarks, service marks, and logos contained therein (the "Marks").
+
+Our Content and Marks are protected by copyright and trademark laws (and various other intellectual property rights and unfair competition laws) and treaties in the United States and around the world.
+
+The Content and Marks are provided in or through the Services "AS IS" for your internal business purpose only.
+
+### Your use of our Services
+
+Subject to your compliance with these Legal Terms, including the "[PROHIBITED ACTIVITIES](#6-prohibited-activities)" section below, we grant you a non-exclusive, non-transferable, revocable license to:
+
+- access the Services; and
+- download or print a copy of any portion of the Content to which you have properly gained access,
+
+solely for your internal business purpose.
+
+Except as set out in this section or elsewhere in our Legal Terms, no part of the Services and no Content or Marks may be copied, reproduced, aggregated, republished, uploaded, posted, publicly displayed, encoded, translated, transmitted, distributed, sold, licensed, or otherwise exploited for any commercial purpose whatsoever, without our express prior written permission.
+
+If you wish to make any use of the Services, Content, or Marks other than as set out in this section or elsewhere in our Legal Terms, please address your request to: [hello@bytestreams.ai](mailto:hello@bytestreams.ai). If we ever grant you the permission to post, reproduce, or publicly display any part of our Services or Content, you must identify us as the owners or licensors of the Services, Content, or Marks and ensure that any copyright or proprietary notice appears or is visible on posting, reproducing, or displaying our Content.
+
+We reserve all rights not expressly granted to you in and to the Services, Content, and Marks.
+
+Any breach of these Intellectual Property Rights will constitute a material breach of our Legal Terms and your right to use our Services will terminate immediately.
+
+### Your submissions
+
+Please review this section and the "[PROHIBITED ACTIVITIES](#6-prohibited-activities)" section carefully prior to using our Services to understand the (a) rights you give us and (b) obligations you have when you post or upload any content through the Services.
+
+**Submissions:** By directly sending us any question, comment, suggestion, idea, feedback, or other information about the Services ("Submissions"), you agree to assign to us all intellectual property rights in such Submission. You agree that we shall own this Submission and be entitled to its unrestricted use and dissemination for any lawful purpose, commercial or otherwise, without acknowledgment or compensation to you.
+
+**You are responsible for what you post or upload:** By sending us Submissions through any part of the Services you:
+
+- confirm that you have read and agree with our "[PROHIBITED ACTIVITIES](#6-prohibited-activities)" and will not post, send, publish, upload, or transmit through the Services any Submission that is illegal, harassing, hateful, harmful, defamatory, obscene, bullying, abusive, discriminatory, threatening to any person or group, sexually explicit, false, inaccurate, deceitful, or misleading;
+- to the extent permissible by applicable law, waive any and all moral rights to any such Submission;
+- warrant that any such Submission are original to you or that you have the necessary rights and licenses to submit such Submissions and that you have full authority to grant us the above-mentioned rights in relation to your Submissions; and
+- warrant and represent that your Submissions do not constitute confidential information.
+
+You are solely responsible for your Submissions and you expressly agree to reimburse us for any and all losses that we may suffer because of your breach of (a) this section, (b) any third party's intellectual property rights, or (c) applicable law.
+
+## 3. USER REPRESENTATIONS
+
+By using the Services, you represent and warrant that: (1) you have the legal capacity and you agree to comply with these Legal Terms; (2) you are not a minor in the jurisdiction in which you reside; (3) you will not access the Services through automated or non-human means, whether through a bot, script or otherwise; (4) you will not use the Services for any illegal or unauthorized purpose; and (5) your use of the Services will not violate any applicable law or regulation.
+
+If you provide any information that is untrue, inaccurate, not current, or incomplete, we have the right to suspend or terminate your account and refuse any and all current or future use of the Services (or any portion thereof).
+
+## 4. PURCHASES AND PAYMENT
+
+We accept the following forms of payment:
+
+- Visa
+- Mastercard
+- American Express
+- PayPal
+- Wire Transfer
+
+You agree to provide current, complete, and accurate purchase and account information for all purchases made via the Services. You further agree to promptly update account and payment information, including email address, payment method, and payment card expiration date, so that we can complete your transactions and contact you as needed. Sales tax will be added to the price of purchases as deemed required by us. We may change prices at any time. All payments shall be in US dollars.
+
+You agree to pay all charges at the prices then in effect for your purchases and any applicable shipping fees, and you authorize us to charge your chosen payment provider for any such amounts upon placing your order. We reserve the right to correct any errors or mistakes in pricing, even if we have already requested or received payment.
+
+We reserve the right to refuse any order placed through the Services. We may, in our sole discretion, limit or cancel quantities purchased per person, per household, or per order. These restrictions may include orders placed by or under the same customer account, the same payment method, and/or orders that use the same billing or shipping address. We reserve the right to limit or prohibit orders that, in our sole judgment, appear to be placed by dealers, resellers, or distributors.
+
+## 5. SUBSCRIPTIONS
+
+### Billing and Renewal
+
+__________
+
+### Free Trial
+
+We offer a __________-day free trial to new users who register with the Services. The account will be charged according to the user's chosen subscription at the end of the free trial.
+
+### Cancellation
+
+All purchases are non-refundable. You can cancel your subscription at any time by contacting us using the contact information provided below. Your cancellation will take effect at the end of the current paid term. If you have any questions or are unsatisfied with our Services, please email us at [hello@bytestreams.ai](mailto:hello@bytestreams.ai).
+
+### Fee Changes
+
+We may, from time to time, make changes to the subscription fee and will communicate any price changes to you in accordance with applicable law.
+
+## 6. PROHIBITED ACTIVITIES
+
+You may not access or use the Services for any purpose other than that for which we make the Services available. The Services may not be used in connection with any commercial endeavors except those that are specifically endorsed or approved by us.
+
+As a user of the Services, you agree not to:
+
+- Systematically retrieve data or other content from the Services to create or compile, directly or indirectly, a collection, compilation, database, or directory without written permission from us.
+- Trick, defraud, or mislead us and other users, especially in any attempt to learn sensitive account information such as user passwords.
+- Circumvent, disable, or otherwise interfere with security-related features of the Services, including features that prevent or restrict the use or copying of any Content or enforce limitations on the use of the Services and/or the Content contained therein.
+- Disparage, tarnish, or otherwise harm, in our opinion, us and/or the Services.
+- Use any information obtained from the Services in order to harass, abuse, or harm another person.
+- Make improper use of our support services or submit false reports of abuse or misconduct.
+- Use the Services in a manner inconsistent with any applicable laws or regulations.
+- Engage in unauthorized framing of or linking to the Services.
+- Upload or transmit (or attempt to upload or to transmit) viruses, Trojan horses, or other material, including excessive use of capital letters and spamming (continuous posting of repetitive text), that interferes with any party's uninterrupted use and enjoyment of the Services or modifies, impairs, disrupts, alters, or interferes with the use, features, functions, operation, or maintenance of the Services.
+- Engage in any automated use of the system, such as using scripts to send comments or messages, or using any data mining, robots, or similar data gathering and extraction tools.
+- Delete the copyright or other proprietary rights notice from any Content.
+- Attempt to impersonate another user or person or use the username of another user.
+- Upload or transmit (or attempt to upload or to transmit) any material that acts as a passive or active information collection or transmission mechanism, including without limitation, clear graphics interchange formats ("gifs"), 1×1 pixels, web bugs, cookies, or other similar devices (sometimes referred to as "spyware" or "passive collection mechanisms" or "pcms").
+- Interfere with, disrupt, or create an undue burden on the Services or the networks or services connected to the Services.
+- Harass, annoy, intimidate, or threaten any of our employees or agents engaged in providing any portion of the Services to you.
+- Attempt to bypass any measures of the Services designed to prevent or restrict access to the Services, or any portion of the Services.
+- Copy or adapt the Services' software, including but not limited to Flash, PHP, HTML, JavaScript, or other code.
+- Except as permitted by applicable law, decipher, decompile, disassemble, or reverse engineer any of the software comprising or in any way making up a part of the Services.
+- Except as may be the result of standard search engine or Internet browser usage, use, launch, develop, or distribute any automated system, including without limitation, any spider, robot, cheat utility, scraper, or offline reader that accesses the Services, or use or launch any unauthorized script or other software.
+- Use a buying agent or purchasing agent to make purchases on the Services.
+- Make any unauthorized use of the Services, including collecting usernames and/or email addresses of users by electronic or other means for the purpose of sending unsolicited email, or creating user accounts by automated means or under false pretenses.
+- Use the Services as part of any effort to compete with us or otherwise use the Services and/or the Content for any revenue-generating endeavor or commercial enterprise.
+- Use Service for purchasing, schedule appointments and cancellations, and answer business related questions.
+
+## 7. USER GENERATED CONTRIBUTIONS
+
+The Services does not offer users to submit or post content.
+
+## 8. CONTRIBUTION LICENSE
+
+You and Services agree that we may access, store, process, and use any information and personal data that you provide following the terms of the Privacy Policy and your choices (including settings).
+
+By submitting suggestions or other feedback regarding the Services, you agree that we can use and share such feedback for any purpose without compensation to you.
+
+## 9. THIRD-PARTY WEBSITES AND CONTENT
+
+The Services may contain (or you may be sent via the Site) links to other websites ("Third-Party Websites") as well as articles, photographs, text, graphics, pictures, designs, music, sound, video, information, applications, software, and other content or items belonging to or originating from third parties ("Third-Party Content"). Such Third-Party Websites and Third-Party Content are not investigated, monitored, or checked for accuracy, appropriateness, or completeness by us, and we are not responsible for any Third-Party Websites accessed through the Services or any Third-Party Content posted on, available through, or installed from the Services, including the content, accuracy, offensiveness, opinions, reliability, privacy practices, or other policies of or contained in the Third-Party Websites or the Third-Party Content. Inclusion of, linking to, or permitting the use or installation of any Third-Party Websites or any Third-Party Content does not imply approval or endorsement thereof by us. If you decide to leave the Services and access the Third-Party Websites or to use or install any Third-Party Content, you do so at your own risk, and you should be aware these Legal Terms no longer govern. You should review the applicable terms and policies, including privacy and data gathering practices, of any website to which you navigate from the Services or relating to any applications you use or install from the Services. Any purchases you make through Third-Party Websites will be through other websites and from other companies, and we take no responsibility whatsoever in relation to such purchases which are exclusively between you and the applicable third party. You agree and acknowledge that we do not endorse the products or services offered on Third-Party Websites and you shall hold us blameless from any harm caused by your purchase of such products or services. Additionally, you shall hold us blameless from any losses sustained by you or harm caused to you relating to or resulting in any way from any Third-Party Content or any contact with Third-Party Websites.
+
+## 10. SERVICES MANAGEMENT
+
+We reserve the right, but not the obligation, to: (1) monitor the Services for violations of these Legal Terms; (2) take appropriate legal action against anyone who, in our sole discretion, violates the law or these Legal Terms, including without limitation, reporting such user to law enforcement authorities; (3) in our sole discretion and without limitation, refuse, restrict access to, limit the availability of, or disable (to the extent technologically feasible) any of your Contributions or any portion thereof; (4) in our sole discretion and without limitation, notice, or liability, to remove from the Services or otherwise disable all files and content that are excessive in size or are in any way burdensome to our systems; and (5) otherwise manage the Services in a manner designed to protect our rights and property and to facilitate the proper functioning of the Services.
+
+## 11. PRIVACY POLICY
+
+We care about data privacy and security. Please review our Privacy Policy: [http://www.bytestreams.ai/cookies.html](http://www.bytestreams.ai/cookies.html). By using the Services, you agree to be bound by our Privacy Policy, which is incorporated into these Legal Terms. Please be advised the Services are hosted in the United States. If you access the Services from any other region of the world with laws or other requirements governing personal data collection, use, or disclosure that differ from applicable laws in the United States, then through your continued use of the Services, you are transferring your data to the United States, and you expressly consent to have your data transferred to and processed in the United States.
+
+## 12. TERM AND TERMINATION
+
+These Legal Terms shall remain in full force and effect while you use the Services. WITHOUT LIMITING ANY OTHER PROVISION OF THESE LEGAL TERMS, WE RESERVE THE RIGHT TO, IN OUR SOLE DISCRETION AND WITHOUT NOTICE OR LIABILITY, DENY ACCESS TO AND USE OF THE SERVICES (INCLUDING BLOCKING CERTAIN IP ADDRESSES), TO ANY PERSON FOR ANY REASON OR FOR NO REASON, INCLUDING WITHOUT LIMITATION FOR BREACH OF ANY REPRESENTATION, WARRANTY, OR COVENANT CONTAINED IN THESE LEGAL TERMS OR OF ANY APPLICABLE LAW OR REGULATION. WE MAY TERMINATE YOUR USE OR PARTICIPATION IN THE SERVICES OR DELETE ANY CONTENT OR INFORMATION THAT YOU POSTED AT ANY TIME, WITHOUT WARNING, IN OUR SOLE DISCRETION.
+
+If we terminate or suspend your account for any reason, you are prohibited from registering and creating a new account under your name, a fake or borrowed name, or the name of any third party, even if you may be acting on behalf of the third party. In addition to terminating or suspending your account, we reserve the right to take appropriate legal action, including without limitation pursuing civil, criminal, and injunctive redress.
+
+## 13. MODIFICATIONS AND INTERRUPTIONS
+
+We reserve the right to change, modify, or remove the contents of the Services at any time or for any reason at our sole discretion without notice. However, we have no obligation to update any information on our Services. We will not be liable to you or any third party for any modification, price change, suspension, or discontinuance of the Services.
+
+We cannot guarantee the Services will be available at all times. We may experience hardware, software, or other problems or need to perform maintenance related to the Services, resulting in interruptions, delays, or errors. We reserve the right to change, revise, update, suspend, discontinue, or otherwise modify the Services at any time or for any reason without notice to you. You agree that we have no liability whatsoever for any loss, damage, or inconvenience caused by your inability to access or use the Services during any downtime or discontinuance of the Services. Nothing in these Legal Terms will be construed to obligate us to maintain and support the Services or to supply any corrections, updates, or releases in connection therewith.
+
+## 14. GOVERNING LAW
+
+These Legal Terms and your use of the Services are governed by and construed in accordance with the laws of the State of Tennessee applicable to agreements made and to be entirely performed within the State of Tennessee, without regard to its conflict of law principles.
+
+## 15. DISPUTE RESOLUTION
+
+### Informal Negotiations
+
+To expedite resolution and control the cost of any dispute, controversy, or claim related to these Legal Terms (each a "Dispute" and collectively, the "Disputes") brought by either you or us (individually, a "Party" and collectively, the "Parties"), the Parties agree to first attempt to negotiate any Dispute (except those Disputes expressly provided below) informally for at least thirty (30) days before initiating arbitration. Such informal negotiations commence upon written notice from one Party to the other Party.
+
+### Binding Arbitration
+
+Any dispute arising out of or in connection with these Legal Terms, including any question regarding its existence, validity, or termination, shall be referred to and finally resolved by the International Commercial Arbitration Court under the European Arbitration Chamber (Belgium, Brussels, Avenue Louise, 146) according to the Rules of this ICAC, which, as a result of referring to it, is considered as the part of this clause. The number of arbitrators shall be __________. The seat, or legal place, or arbitration shall be __________. The language of the proceedings shall be __________. The governing law of these Legal Terms shall be substantive law of __________.
+
+### Restrictions
+
+The Parties agree that any arbitration shall be limited to the Dispute between the Parties individually. To the full extent permitted by law, (a) no arbitration shall be joined with any other proceeding; (b) there is no right or authority for any Dispute to be arbitrated on a class-action basis or to utilize class action procedures; and (c) there is no right or authority for any Dispute to be brought in a purported representative capacity on behalf of the general public or any other persons.
+
+### Exceptions to Informal Negotiations and Arbitration
+
+The Parties agree that the following Disputes are not subject to the above provisions concerning informal negotiations binding arbitration: (a) any Disputes seeking to enforce or protect, or concerning the validity of, any of the intellectual property rights of a Party; (b) any Dispute related to, or arising from, allegations of theft, piracy, invasion of privacy, or unauthorized use; and (c) any claim for injunctive relief. If this provision is found to be illegal or unenforceable, then neither Party will elect to arbitrate any Dispute falling within that portion of this provision found to be illegal or unenforceable and such Dispute shall be decided by a court of competent jurisdiction within the courts listed for jurisdiction above, and the Parties agree to submit to the personal jurisdiction of that court.
+
+## 16. CORRECTIONS
+
+There may be information on the Services that contains typographical errors, inaccuracies, or omissions, including descriptions, pricing, availability, and various other information. We reserve the right to correct any errors, inaccuracies, or omissions and to change or update the information on the Services at any time, without prior notice.
+
+## 17. DISCLAIMER
+
+THE SERVICES ARE PROVIDED ON AN AS-IS AND AS-AVAILABLE BASIS. YOU AGREE THAT YOUR USE OF THE SERVICES WILL BE AT YOUR SOLE RISK. TO THE FULLEST EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, IN CONNECTION WITH THE SERVICES AND YOUR USE THEREOF, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE MAKE NO WARRANTIES OR REPRESENTATIONS ABOUT THE ACCURACY OR COMPLETENESS OF THE SERVICES' CONTENT OR THE CONTENT OF ANY WEBSITES OR MOBILE APPLICATIONS LINKED TO THE SERVICES AND WE WILL ASSUME NO LIABILITY OR RESPONSIBILITY FOR ANY (1) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT AND MATERIALS, (2) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO AND USE OF THE SERVICES, (3) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (4) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICES, (5) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE WHICH MAY BE TRANSMITTED TO OR THROUGH THE SERVICES BY ANY THIRD PARTY, AND/OR (6) ANY ERRORS OR OMISSIONS IN ANY CONTENT AND MATERIALS OR FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF THE USE OF ANY CONTENT POSTED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE SERVICES. WE DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED BY A THIRD PARTY THROUGH THE SERVICES, ANY HYPERLINKED WEBSITE, OR ANY WEBSITE OR MOBILE APPLICATION FEATURED IN ANY BANNER OR OTHER ADVERTISING, AND WE WILL NOT BE A PARTY TO OR IN ANY WAY BE RESPONSIBLE FOR MONITORING ANY TRANSACTION BETWEEN YOU AND ANY THIRD-PARTY PROVIDERS OF PRODUCTS OR SERVICES. AS WITH THE PURCHASE OF A PRODUCT OR SERVICE THROUGH ANY MEDIUM OR IN ANY ENVIRONMENT, YOU SHOULD USE YOUR BEST JUDGMENT AND EXERCISE CAUTION WHERE APPROPRIATE.
+
+## 18. LIMITATIONS OF LIABILITY
+
+IN NO EVENT WILL WE OR OUR DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT, INDIRECT, CONSEQUENTIAL, EXEMPLARY, INCIDENTAL, SPECIAL, OR PUNITIVE DAMAGES, INCLUDING LOST PROFIT, LOST REVENUE, LOSS OF DATA, OR OTHER DAMAGES ARISING FROM YOUR USE OF THE SERVICES, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO YOU FOR ANY CAUSE WHATSOEVER AND REGARDLESS OF THE FORM OF THE ACTION, WILL AT ALL TIMES BE LIMITED TO $1,000.00 USD. CERTAIN US STATE LAWS AND INTERNATIONAL LAWS DO NOT ALLOW LIMITATIONS ON IMPLIED WARRANTIES OR THE EXCLUSION OR LIMITATION OF CERTAIN DAMAGES. IF THESE LAWS APPLY TO YOU, SOME OR ALL OF THE ABOVE DISCLAIMERS OR LIMITATIONS MAY NOT APPLY TO YOU, AND YOU MAY HAVE ADDITIONAL RIGHTS.
+
+## 19. INDEMNIFICATION
+
+You agree to defend, indemnify, and hold us harmless, including our subsidiaries, affiliates, and all of our respective officers, agents, partners, and employees, from and against any loss, damage, liability, claim, or demand, including reasonable attorneys' fees and expenses, made by any third party due to or arising out of: (1) use of the Services; (2) breach of these Legal Terms; (3) any breach of your representations and warranties set forth in these Legal Terms; (4) your violation of the rights of a third party, including but not limited to intellectual property rights; or (5) any overt harmful act toward any other user of the Services with whom you connected via the Services. Notwithstanding the foregoing, we reserve the right, at your expense, to assume the exclusive defense and control of any matter for which you are required to indemnify us, and you agree to cooperate, at your expense, with our defense of such claims. We will use reasonable efforts to notify you of any such claim, action, or proceeding which is subject to this indemnification upon becoming aware of it.
+
+## 20. USER DATA
+
+We will maintain certain data that you transmit to the Services for the purpose of managing the performance of the Services, as well as data relating to your use of the Services. Although we perform regular routine backups of data, you are solely responsible for all data that you transmit or that relates to any activity you have undertaken using the Services. You agree that we shall have no liability to you for any loss or corruption of any such data, and you hereby waive any right of action against us arising from any such loss or corruption of such data.
+
+## 21. ELECTRONIC COMMUNICATIONS, TRANSACTIONS, AND SIGNATURES
+
+Visiting the Services, sending us emails, and completing online forms constitute electronic communications. You consent to receive electronic communications, and you agree that all agreements, notices, disclosures, and other communications we provide to you electronically, via email and on the Services, satisfy any legal requirement that such communication be in writing. YOU HEREBY AGREE TO THE USE OF ELECTRONIC SIGNATURES, CONTRACTS, ORDERS, AND OTHER RECORDS, AND TO ELECTRONIC DELIVERY OF NOTICES, POLICIES, AND RECORDS OF TRANSACTIONS INITIATED OR COMPLETED BY US OR VIA THE SERVICES. You hereby waive any rights or requirements under any statutes, regulations, rules, ordinances, or other laws in any jurisdiction which require an original signature or delivery or retention of non-electronic records, or to payments or the granting of credits by any means other than electronic means.
+
+## 22. SMS TEXT MESSAGING
+
+### Program Description
+
+By opting into any Customers Brand Name text messaging program, you expressly consent to receive text messages (SMS) to your mobile number. Customers Brand Name text messages may include: order updates.
+
+### Message Frequency
+
+When you opt in to our SMS messaging service, you should expect to receive minimum of 3 SMS Messages. One to opt in to service, One to receive payment processing. One for payment confirmation. However there may be more when reservations, order changes, or marketing campaigns are involved. 
+
+### Opting Out
+
+If at any time you wish to stop receiving SMS messages from us, simply reply to the text with "STOP." You may receive an SMS message confirming your opt out. After this, you will no longer receive SMS messages from us. If you want to join again, please sign up as you did the first time and we will start sending SMS messages to you again.
+
+### Message and Data Rates
+
+Please be aware that message and data rates may apply to any SMS messages sent or received. The rates are determined by your carrier and the specifics of your mobile plan. Carriers are not liable for delayed or undelivered messages. If you have any questions about your text plan or data plan, contact your wireless provider.
+
+### Support
+
+If you have any questions or need assistance regarding our SMS communications, please reply with the keyword HELP. You can also email us at [hello@bytestreams.ai](mailto:hello@bytestreams.ai) or call at 629-282-9555. If you have any questions regarding privacy, please read our Privacy Policy: [http://www.bytestreams.ai/cookies.html](http://www.bytestreams.ai/cookies.html).
+
+## 23. CALIFORNIA USERS AND RESIDENTS
+
+If any complaint with us is not satisfactorily resolved, you can contact the Complaint Assistance Unit of the Division of Consumer Services of the California Department of Consumer Affairs in writing at 1625 North Market Blvd., Suite N 112, Sacramento, California 95834 or by telephone at (800) 952-5210 or (916) 445-1254.
+
+## 24. MISCELLANEOUS
+
+These Legal Terms and any policies or operating rules posted by us on the Services or in respect to the Services constitute the entire agreement and understanding between you and us. Our failure to exercise or enforce any right or provision of these Legal Terms shall not operate as a waiver of such right or provision. These Legal Terms operate to the fullest extent permissible by law. We may assign any or all of our rights and obligations to others at any time. We shall not be responsible or liable for any loss, damage, delay, or failure to act caused by any cause beyond our reasonable control. If any provision or part of a provision of these Legal Terms is determined to be unlawful, void, or unenforceable, that provision or part of the provision is deemed severable from these Legal Terms and does not affect the validity and enforceability of any remaining provisions. There is no joint venture, partnership, employment or agency relationship created between you and us as a result of these Legal Terms or use of the Services. You agree that these Legal Terms will not be construed against us by virtue of having drafted them. You hereby waive any and all defenses you may have based on the electronic form of these Legal Terms and the lack of signing by the parties hereto to execute these Legal Terms.
+
+## 25. CONTACT US
+
+In order to resolve a complaint regarding the Services or to receive further information regarding use of the Services, please contact us at:
+
+**bytestreams**
+501 Union St Ste 545
+Nashville, TN 37219
+United States
+Phone: 629-282-9555
+[hello@bytestreams.ai](mailto:hello@bytestreams.ai)

--- a/docs/voice-agent-consent-script.md
+++ b/docs/voice-agent-consent-script.md
@@ -1,0 +1,238 @@
+# DialTone Voice Agent — SMS Consent Script & Logging Spec
+
+**Purpose:** Define the exact words the AI agent speaks to capture SMS consent, and the data DialTone must log to prove the consent exists if a carrier, customer, or regulator ever asks.
+
+**Why consent is at the START of the call, not the end:** DialTone's ordering flow requires SMS to complete the transaction. After the order is finalized on the call, the customer receives a Stripe payment link via SMS. Without payment, the order never enters the kitchen. This means SMS consent is a gating condition — the agent cannot usefully take the order unless the customer has consented to SMS. Placing consent at the top of the call lets the agent either proceed with confidence or transfer the caller to restaurant staff without wasting the customer's time taking an order that can't be completed.
+
+**Why this matters for 10DLC:** When you tell a reviewer "customers opt in verbally during the phone call," the reviewer may ask you to demonstrate how. If your answer is hand-wavy ("the agent kind of asks"), the campaign gets rejected. If your answer is "here's the exact script, here's the log record format, here's an example transcript, here's what happens when they say no," the reviewer has what they need.
+
+---
+
+## The Consent Moment — Exact Agent Script
+
+The agent speaks this language immediately after greeting the caller, before taking any order information. This is the only place in the call flow where consent is captured.
+
+### Primary script (start of call)
+
+> "Thanks for calling {{Restaurant_Name}}! I can take your order right now. Just so you know, to finish your order I'll need to text you a payment link from Stripe, and I'll also text you a confirmation when payment clears and another text when your order is ready. Message and data rates may apply, and you can reply STOP anytime to unsubscribe. Is it OK to text you at the number you're calling from?"
+
+### If caller says "yes"
+
+> "Great. Just to confirm, that's the number ending in [READ BACK LAST FOUR DIGITS] — right?"
+
+**Only after the caller confirms the number** does the agent proceed to take the order:
+
+> "Perfect. What can I get started for you?"
+
+### If caller says "no"
+
+> "No problem — let me transfer you to the restaurant so they can take your order directly. One moment."
+
+The agent then executes the transfer to the restaurant's configured staff line. No consent record is created. No order is attempted.
+
+### If caller asks a follow-up question ("what kind of texts?", "how often?", "why do I need to do this?")
+
+> "Just three texts — a payment link to finish your order, a confirmation when your card clears, and a heads-up when your order's ready. Nothing promotional unless you separately opt in later. You can reply STOP anytime. Sound OK?"
+
+### If caller says something ambiguous ("I guess so", "sure whatever", "yeah I mean OK")
+
+The agent must re-prompt for a clear yes or no. Ambiguous responses do not satisfy TCPA's "express consent" standard.
+
+> "Just to make sure I heard that right — is that a yes to the texts, or would you rather I transfer you to the restaurant?"
+
+### If caller wants the texts sent to a different number
+
+> "Got it. What's the best number to text for this order?"
+
+After the caller provides the number, the agent reads it back digit-by-digit and asks for confirmation:
+
+> "Let me read that back — [DIGIT BY DIGIT]. Is that correct?"
+
+**Only after the caller confirms** does the agent proceed. If there's any doubt about the number, the agent asks the caller to spell it again or offers to use the calling number instead.
+
+---
+
+## Optional Promotional Consent (separate, offered late in the call)
+
+Promotional consent is **separate** from the mandatory transactional consent. It is offered near the end of a successful order, never at the start. It is always optional.
+
+### If the restaurant has the Marketing add-on enabled
+
+After the order is finalized but before ending the call:
+
+> "Quick one before I let you go — want me to add you to occasional offers from {{Restaurant_Name}}? No more than two texts a month, things like a weekend special or a promo code. You can reply STOP anytime."
+
+Record promotional consent separately: `promotional_consent: true` or `false`. Default is `false`.
+
+### If the restaurant does NOT have the Marketing add-on
+
+Skip this prompt entirely. Do not ask.
+
+---
+
+## Why the script is written this way
+
+**Consent is captured before any order details.**
+Taking an order and then discovering the customer won't consent to SMS wastes the customer's time and yours. Up-front gating respects everyone.
+
+**The script explains *why* SMS is needed.**
+"To finish your order I'll need to text you a payment link" gives the customer a concrete reason. Vague "can we text you?" prompts get "no" far more often than specific ones.
+
+**It names the brand.**
+Carrier reviewers look for this. A consent prompt that doesn't identify the sender fails.
+
+**It enumerates the message types.**
+"Payment link, payment confirmation, order ready" — the customer knows exactly what they're agreeing to receive.
+
+**It includes required disclosures.**
+"Message and data rates may apply" and "reply STOP anytime" are TCPA/carrier-required and must be present at the consent moment, not just in the messages themselves.
+
+**It confirms the phone number.**
+Prevents accidentally messaging the wrong number. Caller ID spoofing is real; so are shared business lines.
+
+**It handles "no" gracefully.**
+Transferring to staff preserves the customer relationship and the restaurant's revenue. A customer who hears "we can't help you" will remember that. A customer who hears "let me get you someone who can take this by phone" will not.
+
+**It separates transactional and promotional consent.**
+TCPA requires separate, express consent for marketing messages. Bundling the two is a documented violation.
+
+**Ambiguous responses force re-prompt.**
+"I guess so" is not express consent. Courts have ruled on this repeatedly. The script treats ambiguity as a soft no and re-prompts.
+
+---
+
+## Consent Log Record — Required Fields
+
+Every consent event must produce a log record with at least these fields. Store these in Supabase (the `sms_consents` table) with row-level security so each restaurant can only see their own records.
+
+| Field | Type | Example | Notes |
+|---|---|---|---|
+| `consent_id` | uuid | `b3f5c...` | Primary key |
+| `restaurant_id` | uuid | `rest_abc123` | FK to restaurants table |
+| `call_id` | uuid | `call_xyz789` | FK to the Vapi call record |
+| `phone_number` | E.164 string | `+16155551234` | The number that will receive SMS |
+| `phone_number_source` | enum | `calling_number` | `calling_number` \| `provided_by_caller` \| `website_form` |
+| `phone_number_confirmed` | boolean | `true` | Did the caller confirm the number on the call? |
+| `consent_timestamp` | timestamptz | `2026-04-22T18:42:17Z` | The exact moment "yes" was said |
+| `transactional_consent` | boolean | `true` | Payment link + confirmation + ready notifications |
+| `promotional_consent` | boolean | `false` | Marketing messages — default false |
+| `promotional_consent_timestamp` | timestamptz \| null | `null` | Populated only if separate promo consent captured |
+| `consent_method` | enum | `voice` | `voice` \| `web_form` \| `sms_keyword` |
+| `consent_language_version` | string | `v1.0` | Which version of the consent script was used |
+| `call_recording_url` | string | `https://...` | Link to the Vapi recording |
+| `transcript_consent_excerpt` | text | *"...to finish your order I'll need to text..."* | The exact words spoken at the consent moment |
+| `caller_ip_address` | inet | `null` for voice | Populated for web form consents |
+| `user_agent` | text | `null` for voice | Populated for web form consents |
+| `opt_out_timestamp` | timestamptz \| null | `null` | Populated when customer replies STOP |
+
+**Retention:** Keep consent records for at least **4 years** after the most recent message sent to that number. TCPA statutes of limitation are typically 2 years, but carriers and plaintiffs' attorneys frequently cite 4 years to cover state law variations. Your lawyer will confirm.
+
+---
+
+## What Happens When Consent is Refused
+
+When the customer declines SMS consent, the flow is:
+
+1. Agent speaks the refusal script ("No problem — let me transfer you to the restaurant...").
+2. Agent executes a warm transfer to the restaurant's configured `staff_transfer_number`.
+3. **No consent record is created.** No partial record. No "pending" record.
+4. **No order is attempted.** The customer's order will be taken by restaurant staff directly, outside DialTone.
+5. The call is logged with `outcome: transferred_no_consent` for billing/analytics purposes. This call does NOT count as a completed paid order for billing — the restaurant is not charged.
+6. The caller's phone number is NOT added to any suppression list. They're simply not a DialTone customer for this interaction. If they call back tomorrow and consent, that's a clean new interaction.
+
+**Why this matters:** The refusal branch needs to be as clean as the accept branch. If any trace of the refused consent shows up in the database (even as "denied"), it creates ambiguity about whether consent was ever granted. The rule is: no consent record unless consent was actually granted.
+
+---
+
+## Example Consent Log Record (for your 10DLC submission)
+
+If a reviewer asks "can you show me what a consent record looks like?", be ready to show this:
+
+```json
+{
+  "consent_id": "b3f5c4a2-8f12-4e91-b0c3-2a5d7f9e1234",
+  "restaurant_id": "rest_milanos_nashville",
+  "call_id": "call_01HXY9Z8K2M3N4P5Q6R7S8T9",
+  "phone_number": "+16155551234",
+  "phone_number_source": "calling_number",
+  "phone_number_confirmed": true,
+  "consent_timestamp": "2026-04-22T18:42:17.334Z",
+  "transactional_consent": true,
+  "promotional_consent": true,
+  "promotional_consent_timestamp": "2026-04-22T18:47:02.811Z",
+  "consent_method": "voice",
+  "consent_language_version": "v1.0",
+  "call_recording_url": "https://recordings.dialtone.menu/call_01HXY...mp3",
+  "transcript_consent_excerpt": "Agent: Thanks for calling Milano's Pizzeria! I can take your order right now. Just so you know, to finish your order I'll need to text you a payment link from Stripe, and I'll also text you a confirmation when payment clears and another text when your order is ready. Message and data rates may apply, and you can reply STOP anytime to unsubscribe. Is it OK to text you at the number you're calling from? Caller: Yeah, that's fine. Agent: Great. Just to confirm, that's the number ending in one-two-three-four — right? Caller: Yes. Agent: Perfect. What can I get started for you?",
+  "caller_ip_address": null,
+  "user_agent": null,
+  "opt_out_timestamp": null
+}
+```
+
+---
+
+## Edge Cases to Handle
+
+**1. Caller is silent after the consent prompt.**
+After 4 seconds of silence, agent re-prompts once: "Are you still there? Just need a yes or no on the texts to continue." If still silent, agent wraps up politely and transfers to staff.
+
+**2. Caller hangs up after the consent prompt but before answering.**
+No consent record, no transfer, no order. Log `outcome: abandoned_at_consent` for analytics.
+
+**3. Caller consents but then the call drops before the order is taken.**
+The consent record is valid and retained. If the caller calls back later, the existing consent can be honored (for example, re-sending the payment link for an order placed in a follow-up call). But be cautious: the safer default is to re-capture consent on the new call unless you're confident the same number is calling and the intent is continuous.
+
+**4. Caller asks "can I just order without the text?"**
+> "Totally fair. I can't complete the payment through this AI line without texting you the link, but I can transfer you to the restaurant so they can take your order directly. Want me to do that?"
+
+**5. Caller is a minor.**
+DialTone has no reliable way to verify age on a voice call. If the voice agent detects clear youth-voice cues, the agent should decline to capture SMS consent and should transfer the call to restaurant staff. *Your lawyer should weigh in on the youth-voice detection threshold and whether this transfer should happen silently or with a disclosure to the caller.*
+
+**6. Caller provides a different number than the calling number.**
+Covered in the script. Read back digit-by-digit, require explicit confirmation, store as `phone_number_source: provided_by_caller`.
+
+**7. Caller revokes consent mid-call ("actually, never mind, don't text me").**
+Immediately honor. Mark any provisional consent record as revoked (or delete it — your lawyer can advise on retention). Transfer to staff if the order isn't complete, or end the call gracefully if it is.
+
+**8. Caller asks to be opted out but has never opted in.**
+Record the opt-out anyway as a suppression entry for that restaurant. Costs nothing; protects against re-messaging if they ever do opt in and then forget.
+
+**9. Promotional consent is requested but the Marketing add-on is not enabled.**
+This should never happen if the code is correct. If it does, do not send promotional messages regardless of consent. Audit the code path.
+
+**10. Caller consents to transactional but not promotional.**
+This is a legitimate and common outcome. `transactional_consent: true`, `promotional_consent: false`. Do not send promotional messages to this number even if the caller later places repeated orders.
+
+---
+
+## How This Script Should Appear in DialTone's Codebase
+
+The consent script should live in a versioned config file (for example, `consent_scripts/voice_v1.0.ts`) so that:
+
+- The exact language used for each consent event is recoverable for audits
+- Changes to the script get a new version number, never overwrite
+- The `consent_language_version` field in the log record is a real FK or version identifier
+- A legal review of the script (pre-deployment) leaves a paper trail tied to a specific version
+
+Don't hardcode the script into Vapi's system prompt as free text. Version it. Treat it like a legal artifact, not a UX string. When your lawyer blesses a version, that version number goes into every consent record captured while it was live.
+
+---
+
+## Integration With the Flow Diagram
+
+Mapping to your `functional-process-flow` diagram:
+
+| Flow node | What happens |
+|---|---|
+| `Customer calls` | Call arrives at Twilio |
+| `Twilio routes call` | Forwarded to Vapi |
+| `Vapi voice assistant` | Agent greets caller and immediately runs the **consent script** above |
+| *(new: consent branch)* | If yes → proceed to `Customer intent`. If no → transfer to staff, end call. |
+| `Customer intent` | Classify into order / reservation / knowledge |
+| `finalize_order` → `Create order (pending_payment)` | Order is created only because consent was already captured |
+| `Create Stripe payment link` → `Send payment link via Twilio SMS` | First SMS sent under consent |
+| `Stripe webhook: payment_intent.succeeded` → `Order status becomes paid` → `Kitchen board receives new paid order` | Second SMS (payment confirmation) sent around this stage |
+| `Staff advances status: preparing → ready → completed` | Third SMS (order ready) sent when status reaches `ready` |
+
+The consent check is effectively a **new node** that sits between `Vapi voice assistant` and `Customer intent`. Consider updating the flow diagram to reflect this — it's an architectural detail, not just a UX one.

--- a/github/ISSUES/copy-updates-footer-navigation.md
+++ b/github/ISSUES/copy-updates-footer-navigation.md
@@ -1,0 +1,60 @@
+# chore(copy, footer): update footer row copy and product links
+
+## Summary
+
+Update footer navigation copy and ordering to match the requested row-first reading pattern beside the logo.
+
+Requested reading order:
+- Row 1: Company -> About -> Security
+- Row 2: Product -> DialTone.menu -> DialTone.med (comming soon) -> Features
+- Row 3: Legal -> Privacy -> Terms -> Cookie Policy
+
+Also link `DialTone.menu` to its live domain.
+
+---
+
+## Changes
+
+1. Reworked footer content ordering and wording
+- Switched from column-first navigation to row-first copy structure.
+- Added row labels for `Company`, `Product`, and `Legal` with left-to-right link flow.
+
+2. Product link updates
+- Linked `DialTone.menu` to `https://dialtone.menu`.
+- Kept `DialTone.med` as placeholder and updated label text to:
+  - `DialTone.med (comming soon)`
+
+3. Legal links
+- Ensured `Cookie Policy` points to `cookies.html`.
+
+4. New legal page included in nav
+- `cookies.html` added and included in footer legal links.
+
+---
+
+## Files Touched
+
+- `index.html`
+- `privacy.html`
+- `terms.html`
+- `cookies.html`
+- `sass/layout/_footer.scss`
+- `sass/base/_typography.scss`
+- `dist/css/main.css`
+
+---
+
+## Acceptance Criteria
+
+- Footer reads top-down by rows next to logo: Company, Product, Legal.
+- Within each row, links read left-to-right with separators.
+- `DialTone.menu` opens `https://dialtone.menu`.
+- `DialTone.med` displays `DialTone.med (comming soon)`.
+- `Cookie Policy` links to `cookies.html` on all pages.
+
+---
+
+## Labels
+
+- `enhancement`
+- `documentation`

--- a/index.html
+++ b/index.html
@@ -308,28 +308,33 @@ US</p>
                     </p>
                 </div>
 
-                <div>
-                    <p class="footer__column-title">Product</p>
-                    <ul class="footer__links">
-                        <li><a href="#features" class="footer__link">Features</a></li>
-                    </ul>
-                </div>
+                <div class="footer__site-map" aria-label="Footer site links">
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Company</p>
+                        <ul class="footer__site-links">
+                            <li><a href="#about" class="footer__link">About</a></li>
+                            <li><a href="#" class="footer__link">Security</a></li>
+                        </ul>
+                    </div>
 
-                <div>
-                    <p class="footer__column-title">Company</p>
-                    <ul class="footer__links">
-                        <li><a href="#about" class="footer__link">About</a></li>
-                        <li><a href="#" class="footer__link">Security</a></li>
-                    </ul>
-                </div>
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Product</p>
+                        <ul class="footer__site-links">
+                            <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="#features" class="footer__link">Features</a></li>
+                        </ul>
+                    </div>
 
-                <div>
-                    <p class="footer__column-title">Legal</p>
-                    <ul class="footer__links">
-                        <li><a href="privacy.html" class="footer__link">Privacy</a></li>
-                        <li><a href="terms.html" class="footer__link">Terms</a></li>
-                        <li><a href="#" class="footer__link">Cookie Policy</a></li>
-                    </ul>
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Legal</p>
+                        <ul class="footer__site-links">
+                            <li><a href="privacy.html" class="footer__link">Privacy</a></li>
+                            <li><a href="terms.html" class="footer__link">Terms</a></li>
+                            <li><a href="sms-terms.html" class="footer__link">SMS Terms</a></li>
+                            <li><a href="cookies.html" class="footer__link">Cookie Policy</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
 

--- a/privacy.html
+++ b/privacy.html
@@ -53,9 +53,307 @@
     <main class="section">
         <div class="section__container">
             <header class="section__header">
-                <h1 class="section__title">Privacy Policy</h1>
-                <p class="section__subtitle">Last updated: April 21, 2026</p>
+                <h1 class="section__title">Privacy Notice</h1>
+                <p class="section__subtitle">Last Update 21 April 2026</p>
             </header>
+
+            <article class="legal-doc">
+                <p>
+                    The Privacy Notice for bytestreams LLC (<strong>&quot;we&quot;</strong>, <strong>&quot;us&quot;</strong>, or <strong>&quot;our&quot;</strong>),
+                    describes how and why we might access, collect, store, use, and/or share (&quot;process&quot;) your personal
+                    information when you use our services (&quot;Services&quot;), including when you:
+                </p>
+
+                <p>
+                    <strong>Questions or concerns ?</strong> Reading this Privacy Notice will help you understand your
+                    privacy rights and choices. We are responsible for making decisions about how your personal information
+                    is processed. If you do not agree with our policies and practices, please do use our Services.
+                </p>
+
+                <h2>SUMMARY OF KEY POINTS</h2>
+                <p>
+                    This summary provides key points from our Privacy Notice, but you can find out more details about any of
+                    these topics by clicking the link following each key point or by using our <code>table of contents</code>
+                    below to find the section you are looking for.
+                </p>
+
+                <p>
+                    <strong>What personal information do we process ?</strong> When you visit, use, or navigate our
+                    Services, we may process personal information depending on how you interact with us and our services,
+                    the choices you make, the products and features you use. Learn more about
+                    <code>personal information you disclose to us.</code>
+                </p>
+
+                <p>
+                    <strong>Do we process any sensitive personal information ?</strong> Some of the information may be
+                    considered &quot;special&quot; or &quot;sensitive&quot; in certain jurisdictions, for example your racial or ethnic
+                    origins, sexual orientation, and religious beliefs. We do not process sensitive personal information.
+                </p>
+
+                <p>
+                    <strong>Do we collect any information from third parties ?&quot;</strong> We do not collect any information
+                    from public databases, marketing partners, social media platforms, and other outside sources. Learn more
+                    about <code>information collected</code> <code>from other sources.</code>
+                </p>
+
+                <p>
+                    <strong>How do we process your information ?</strong> We process your information to provide, improve,
+                    and administer our Services, communicate with you, for security and fraud prevention, and to comply with
+                    law. We may also process your information for other purposes with your consent. We process your
+                    information only when we have a valid legal reason to do so. Learn more about
+                    <code>how we process your information</code>
+                </p>
+
+                <p>
+                    <strong>What are your rights ?</strong> Depending on where you are located geographically, the applicable
+                    privacy law may may mean you have certain rights regarding your personal information. Learn more about
+                    <code>your privacy rights</code>
+                </p>
+
+                <p>
+                    <strong>How do you exercise your rights?</strong> The easiest way to exercise your rights is by
+                    submitting a <code>data subject</code> <code>access request</code>, or by contacting us. We will consider
+                    and act upon any request in accordance with applicable data protection laws.
+                </p>
+
+                <p>
+                    Want to learn more about what we do with any information we collect?
+                    <code>Review the Privacy Notice in full.</code>
+                </p>
+
+                <h2>TABLE OF CONTENTS</h2>
+                <ol>
+                    <li><a href="#1-what-information-do-we-collect">WHAT INFORMATION DO WE COLLECT?</a></li>
+                    <li><a href="#2-how-dowe-process-your-information">HOW DOWE PROCESS YOUR INFORMATION?</a></li>
+                    <li><a href="#3-when-and-with-whom-do-we-share-your-personal-information">WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?</a></li>
+                    <li><a href="#4-do-we-use-cookies-and-other-tracking-technologies">DO WE USE COOKIES AND OTHER TRACKING TECHNOLOGIES?</a></li>
+                    <li><a href="#5-how-do-we-handle-your-social-logins">HOW DO WE HANDLE YOUR SOCIAL LOGINS?</a></li>
+                    <li><a href="#6-is-your-information-transferred-internationally">IS YOUR INFORMATION TRANSFERRED INTERNATIONALLY?</a></li>
+                    <li><a href="#7-how-long-do-we-keep-your-information">HOW LONG DO WE KEEP YOUR INFORMATION?</a></li>
+                    <li><a href="#8-do-we-collect-information-from-minors">DO WE COLLECT INFORMATION FROM MINORS?</a></li>
+                    <li><a href="#9-what-are-your-privacy-rights">WHAT ARE YOUR PRIVACY RIGHTS?</a></li>
+                    <li><a href="#10-controls-for-do-not-track-features">CONTROLS FOR DO-NOT-TRACK FEATURES</a></li>
+                    <li><a href="#11-do-we-make-updates-to-this-notice">DO WE MAKE UPDATES TO THIS NOTICE?</a></li>
+                    <li><a href="#12-how-can-you-contact-us-about-this-notice">HOW CAN YOU CONTACT US ABOUT THIS NOTICE?</a></li>
+                    <li><a href="#13-how-can-you-review-update-or-delete-the-data-we-collect-from-you">HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?</a></li>
+                </ol>
+
+                <h2 id="1-what-information-do-we-collect">1. WHAT INFORMATION DO WE COLLECT?</h2>
+                <h3>Personal Information you disclose to us</h3>
+                <p>In Short: <strong><em>We collect personal information that you provide us.</em></strong></p>
+
+                <p>
+                    We collect personal information that you voluntarily provide us when your accept our request for data
+                    which is used to provide our Services. when you participate in activities on the Services, or otherwise
+                    when you contact us.
+                </p>
+
+                <p><strong>Sensitive Information.</strong> We do not process sensitive information</p>
+
+                <p>
+                    All personal information that you provide to us must be true, complete, and accurate, and you must notify
+                    us of any changes to such personal information.
+                </p>
+
+                <h2 id="2-how-dowe-process-your-information">2. HOW DOWE PROCESS YOUR INFORMATION?</h2>
+                <p>
+                    In short: We process your information to provide, improve, and administer our Services, communicate with
+                    you, for security and fraud prevention, and to comply with law.We may also process your information for
+                    other purposes with your consent.
+                </p>
+
+                <p>
+                    <strong>We process your personal information for a variety of reasons, depending on how you interact with our</strong>
+                    <strong>Services, including:</strong>
+                </p>
+
+                <h2 id="3-when-and-with-whom-do-we-share-your-personal-information">3. WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?</h2>
+                <p>
+                    In Short: <strong><em>We may share information in specific situations described in this section and/or with the</em></strong>
+                    <strong><em>the following third parties</em></strong>
+                </p>
+
+                <p>We may need to share your personal information in the following situations:</p>
+
+                <ul>
+                    <li>
+                        <strong><em>Business Transfers.</em></strong> We may hare or transfer your information in connection with, or
+                        during negotiations of, any merger, sale of company assets, financing, or acquisition of all or a
+                        portion of our business to another company.
+                    </li>
+                    <li>
+                        <strong><em>Affiliates.</em></strong> We may share your information with our affiliates, in which case we will
+                        require those affiliates to honor this Privacy Notice. Affiliates include our parent company and any
+                        subsidiaries, joint venture partners, or other companies that we control or that are under common
+                        control with us.
+                    </li>
+                    <li>
+                        <strong><em>Business Partners.</em></strong> We may share your information with our business partners to offer
+                        you certain products, services, or promotions.
+                    </li>
+                </ul>
+
+                <h2 id="4-do-we-use-cookies-and-other-tracking-technologies">4. DO WE USE COOKIES AND OTHER TRACKING TECHNOLOGIES.</h2>
+                <p>
+                    In Short; No. None of your services are web bases. All of our customer facing traffic is via SMS.
+                    Visitors to our web site can only submit contact information via email and no cookie technologies are
+                    used.
+                </p>
+
+                <p>
+                    Specific information about how we use such technologies can be found in our Cookie Notice.
+                </p>
+
+                <h2 id="5-how-do-we-handle-your-social-logins">5. HOW DO WE HANDLE YOUR SOCIAL LOGINS?</h2>
+                <p>
+                    In Short: <strong><em>If you choose to register or log in to our Services using a social media account, we may have access to certain information about you.</em></strong>
+                </p>
+
+                <p>
+                    Our Services may offer you the ability to register and log in using your third-party social media account
+                    details. If you choose to register or log in using a social media account, we will access certain
+                    information that your social media provider has made available to us in accordance with their terms of
+                    service and your privacy settings on that platform.
+                </p>
+
+                <p>
+                    We will not be responsible for the handling of your information by third-party social media providers. We
+                    encourage you to review their privacy notices and contact them directly regarding their information
+                    practices.
+                </p>
+
+                <h2 id="6-is-your-information-transferred-internationally">6. IS YOUR INFORMATION TRANSFERRED INTERNATIONALLY?</h2>
+                <p>
+                    In Short: <strong><em>If you are accessing our Services from outside the United States, please be aware that your information may be transferred to, stored in, and processed in countries other than your country of residence.</em></strong>
+                </p>
+
+                <p>
+                    Our servers are located in the United States. If you are accessing our Services from outside the United
+                    States, please be aware that your information may be transferred to, stored in, and processed by us in
+                    our facilities and by those third parties with whom we may share your personal information in the United
+                    States and other countries.
+                </p>
+
+                <p>
+                    If you are a resident of the European Union, United Kingdom, or other regions with laws governing data
+                    collection and use that may differ from U.S. law, please note that we transfer information to a country
+                    and jurisdiction that may not have the same data protection laws as your jurisdiction.
+                </p>
+
+                <h2 id="7-how-long-do-we-keep-your-information">7. HOW LONG DO WE KEEP YOUR INFORMATION?</h2>
+                <p>
+                    In Short: <strong><em>We keep your information for as long as necessary to fulfill the purposes outlined in this Privacy Notice unless a longer retention period is required or permitted by law.</em></strong>
+                </p>
+
+                <p>
+                    We will only keep your personal information for as long as it is necessary for the purposes set out in
+                    this Privacy Notice, unless a longer retention period is required or permitted by law. No purpose in this
+                    notice will require us keeping your personal information for longer than the period of time in which users
+                    have an account with us.
+                </p>
+
+                <p>
+                    When you delete your account, we will delete or anonymize your personal information, except where we are
+                    required by law to retain such information.
+                </p>
+
+                <h2 id="8-do-we-collect-information-from-minors">8. DO WE COLLECT INFORMATION FROM MINORS?</h2>
+                <p>
+                    In Short: <strong><em>We do not knowingly collect data from or market to children under 18 years of age.</em></strong>
+                </p>
+
+                <p>
+                    We do not knowingly solicit data from or market to children under 18 years of age. By using our Services,
+                    you represent that you are at least 18 years of age and possess the legal authority to enter into these
+                    terms. If we learn that personal information from users less than 18 years of age has been collected, we
+                    will deactivate the account and take reasonable efforts to promptly remove such data from our records.
+                </p>
+
+                <h2 id="9-what-are-your-privacy-rights">9. WHAT ARE YOUR PRIVACY RIGHTS?</h2>
+                <p>
+                    In Short: <strong><em>In some regions, such as the European Union, you have rights that allow you greater access to and control over your personal information. You may have the right to access, correct, delete, or port your information.</em></strong>
+                </p>
+
+                <p>Depending on your location, you may have the following rights:</p>
+
+                <ul>
+                    <li><strong>Right to Access:</strong> You have the right to request access to the personal information we have collected from you.</li>
+                    <li><strong>Right to Correction:</strong> You have the right to request that we correct inaccurate or incomplete information.</li>
+                    <li><strong>Right to Deletion:</strong> You have the right to request deletion of your personal information, subject to certain exceptions.</li>
+                    <li><strong>Right to Data Portability:</strong> You have the right to request a copy of your information in a portable format.</li>
+                    <li><strong>Right to Withdraw Consent:</strong> Where we rely on your consent to process your information, you have the right to withdraw that consent.</li>
+                    <li><strong>Right to Object:</strong> You have the right to object to the processing of your personal information.</li>
+                </ul>
+
+                <p>
+                    To exercise any of these rights, please submit a data subject access request to us using the contact
+                    information below.
+                </p>
+
+                <h2 id="10-controls-for-do-not-track-features">10. CONTROLS FOR DO-NOT-TRACK FEATURES</h2>
+                <p>
+                    Most web browsers and some mobile operating systems and mobile applications include a Do-Not-Track
+                    (&quot;DNT&quot;) feature or setting you can activate to signal your privacy preference not to have data about
+                    your online browsing activities monitored and collected.
+                </p>
+
+                <p>
+                    At this time, no industry standard has been adopted to recognize or honor DNT signals. However, since we
+                    do not use cookies or other tracking technologies as described in Section 4, DNT preferences are not
+                    applicable to our Services.
+                </p>
+
+                <h2 id="11-do-we-make-updates-to-this-notice">11. DO WE MAKE UPDATES TO THIS NOTICE?</h2>
+                <p>
+                    In Short: <strong><em>Yes, we will update this notice as necessary to stay compliant with relevant laws.</em></strong>
+                </p>
+
+                <p>
+                    We may update this Privacy Notice from time to time to reflect changes in our practices, technology, legal
+                    requirements, or other factors. If we make material changes to this Privacy Notice, we will notify you by
+                    updating the &quot;Last Update&quot; date at the top of this Privacy Notice, and we will take any other steps
+                    required by applicable law.
+                </p>
+
+                <p>
+                    We encourage you to review this Privacy Notice periodically to stay informed about how we protect your
+                    information.
+                </p>
+
+                <h2 id="12-how-can-you-contact-us-about-this-notice">12. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?</h2>
+                <p>If you have questions or comments about this Privacy Notice, please contact us at:</p>
+
+                <p>
+                    <strong>bytestreams LLC</strong><br>
+                    Email: <a href="mailto:privacy@bytestreams.com">privacy@bytestreams.com</a><br>
+                    Mailing Address:<br>
+                    bytestreams LLC<br>
+                    Privacy Team<br>
+                    [Company Address]
+                </p>
+
+                <p>
+                    We will respond to your inquiry within the timeframe required by applicable law, typically within thirty
+                    (30) days.
+                </p>
+
+                <h2 id="13-how-can-you-review-update-or-delete-the-data-we-collect-from-you">13. HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?</h2>
+                <p>
+                    In Short: <strong><em>You have the right to request access to, correct, or delete your personal information.</em></strong>
+                </p>
+
+                <p>
+                    Upon your request, we will provide you with information about whether we hold or process any of your
+                    personal information. You may access, correct, update, or request deletion of your personal information by
+                    contacting us at the information provided in Section 12.
+                </p>
+
+                <p>
+                    To protect your privacy and security, we may ask you to verify your identity before responding to your
+                    request. We will respond to your request in accordance with applicable data protection laws, typically
+                    within thirty (30) days of receipt of your request.
+                </p>
+            </article>
         </div>
     </main>
 

--- a/privacy.html
+++ b/privacy.html
@@ -72,28 +72,33 @@
                     </p>
                 </div>
 
-                <div>
-                    <p class="footer__column-title">Product</p>
-                    <ul class="footer__links">
-                        <li><a href="index.html#features" class="footer__link">Features</a></li>
-                    </ul>
-                </div>
+                <div class="footer__site-map" aria-label="Footer site links">
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Company</p>
+                        <ul class="footer__site-links">
+                            <li><a href="index.html#about" class="footer__link">About</a></li>
+                            <li><a href="#" class="footer__link">Security</a></li>
+                        </ul>
+                    </div>
 
-                <div>
-                    <p class="footer__column-title">Company</p>
-                    <ul class="footer__links">
-                        <li><a href="index.html#about" class="footer__link">About</a></li>
-                        <li><a href="#" class="footer__link">Security</a></li>
-                    </ul>
-                </div>
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Product</p>
+                        <ul class="footer__site-links">
+                            <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="index.html#features" class="footer__link">Features</a></li>
+                        </ul>
+                    </div>
 
-                <div>
-                    <p class="footer__column-title">Legal</p>
-                    <ul class="footer__links">
-                        <li><a href="privacy.html" class="footer__link">Privacy</a></li>
-                        <li><a href="terms.html" class="footer__link">Terms</a></li>
-                        <li><a href="#" class="footer__link">Cookie Policy</a></li>
-                    </ul>
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Legal</p>
+                        <ul class="footer__site-links">
+                            <li><a href="privacy.html" class="footer__link">Privacy</a></li>
+                            <li><a href="terms.html" class="footer__link">Terms</a></li>
+                            <li><a href="sms-terms.html" class="footer__link">SMS Terms</a></li>
+                            <li><a href="cookies.html" class="footer__link">Cookie Policy</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
 

--- a/sass/base/_typography.scss
+++ b/sass/base/_typography.scss
@@ -96,3 +96,38 @@ em     { font-style: italic; }
 .gradient-text {
   @include inherit-text-color;
 }
+
+// Long-form legal/policy content
+.legal-doc {
+  max-width: 840px;
+  margin: 0 auto;
+
+  p,
+  ul {
+    margin-bottom: $space-md;
+  }
+
+  h2 {
+    margin-top: $space-2xl;
+    margin-bottom: $space-md;
+  }
+
+  ul {
+    list-style: disc;
+    padding-left: $space-lg;
+    color: var(--text-muted);
+  }
+
+  li {
+    margin-bottom: $space-sm;
+    line-height: $lh-body;
+  }
+
+  strong {
+    color: var(--text);
+  }
+
+  a {
+    word-break: break-word;
+  }
+}

--- a/sass/layout/_footer.scss
+++ b/sass/layout/_footer.scss
@@ -13,11 +13,11 @@
 
   &__grid {
     display: grid;
-    grid-template-columns: 1.5fr repeat(3, 1fr);
+    grid-template-columns: minmax(220px, 1.2fr) minmax(420px, 2.8fr);
     gap: $space-2xl;
 
     @media (max-width: 900px) {
-      grid-template-columns: 1.2fr repeat(3, 1fr);
+      grid-template-columns: 1fr;
       gap: $space-xl;
     }
 
@@ -78,6 +78,53 @@
 
     &:hover {
       color: $flow-blue;
+    }
+  }
+
+  &__site-map {
+    display: flex;
+    flex-direction: column;
+    gap: $space-md;
+    align-self: center;
+  }
+
+  &__site-row {
+    display: grid;
+    grid-template-columns: 88px minmax(0, 1fr);
+    gap: $space-md;
+    align-items: baseline;
+
+    @include mobile {
+      grid-template-columns: 1fr;
+      gap: $space-xs;
+    }
+  }
+
+  &__site-label {
+    font-size: $font-size-small;
+    font-weight: $weight-semi;
+    color: var(--text);
+    margin: 0;
+    letter-spacing: 0.02em;
+  }
+
+  &__site-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $space-sm;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li {
+      display: inline-flex;
+      align-items: center;
+    }
+
+    li + li::before {
+      content: '->';
+      color: var(--text-faded);
+      margin-right: $space-sm;
     }
   }
 

--- a/sms-terms.html
+++ b/sms-terms.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="ByteStreams SMS Terms and consent policies for DialTone messaging.">
+    <meta name="theme-color" content="#0D1117">
+    <title>SMS Terms &amp; Consent &mdash; ByteStreams</title>
+
+    <link rel="icon" type="image/svg+xml" href="assets/bytestreams-icon-256.svg">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="stylesheet" href="dist/css/main.css">
+</head>
+<body data-theme="dark">
+    <header class="header" id="siteHeader">
+        <div class="header__container">
+            <div class="header__brand">
+                <a href="index.html#home" class="header__logo" aria-label="ByteStreams &mdash; home">
+                    <img src="assets/blue-side-slim-logo.png" alt="ByteStreams" class="header__logo-mark" width="198" height="56">
+                </a>
+                <p class="header__tagline">Smarter Workflows, Stronger Results.</p>
+            </div>
+
+            <nav class="header__nav" id="primaryNav" aria-label="Primary">
+                <ul class="header__nav-list">
+                    <li><a href="index.html#home" class="header__nav-link">Home</a></li>
+                    <li><a href="index.html#features" class="header__nav-link">Features</a></li>
+                    <li><a href="index.html#about" class="header__nav-link">About</a></li>
+                    <li><a href="index.html#contact" class="header__nav-link">Contact</a></li>
+                </ul>
+            </nav>
+
+            <div class="header__actions">
+                <a href="index.html#contact" class="btn btn--primary btn--sm">Get Started</a>
+                <button class="header__hamburger" id="hamburgerBtn" aria-label="Toggle navigation" aria-controls="primaryNav" aria-expanded="false">
+                    <span></span>
+                </button>
+            </div>
+        </div>
+    </header>
+
+    <main class="section">
+        <div class="section__container">
+            <header class="section__header">
+                <h1 class="section__title">SMS Terms &amp; Consent</h1>
+                <p class="section__subtitle">Last updated: April 22, 2026</p>
+            </header>
+
+            <article class="legal-doc">
+                <p>
+                    ByteStreams LLC operates DialTone, an AI voice ordering platform. When you place an order through DialTone,
+                    we may send a Stripe payment link, payment confirmation, and order status updates by SMS. This page explains
+                    consent, message types, opt-out behavior, and support.
+                </p>
+
+                <h2>1. About ByteStreams and DialTone</h2>
+                <p>
+                    ByteStreams LLC is a Tennessee-registered company. Restaurants using DialTone are the sender of record to
+                    their customers. ByteStreams provides the communication infrastructure and consent-capture tooling.
+                </p>
+                <ul>
+                    <li><strong>ByteStreams LLC</strong> - 501 Union St Ste 545, Nashville, TN 37219</li>
+                    <li>Email: <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a></li>
+                    <li>Phone: <a href="tel:+16292829555">629-282-9555</a></li>
+                </ul>
+
+                <h2>2. Consent and Opt-In</h2>
+                <p>
+                    You will only receive SMS messages when consent is provided, including voice consent during calls or checkbox
+                    consent during online ordering. No promotional SMS is sent without separate, explicit opt-in.
+                </p>
+                <p>
+                    Voice consent script includes payment-link disclosure, message frequency notice, potential carrier charges,
+                    and opt-out instructions.
+                </p>
+
+                <h2>3. Message Types</h2>
+                <ul>
+                    <li>Payment link (typically 1 per order)</li>
+                    <li>Payment confirmation (typically 1 per order)</li>
+                    <li>Order-ready or status updates (typically 1-2 per order)</li>
+                    <li>Reservation reminder where supported</li>
+                    <li>Promotional messages only for separately opted-in users</li>
+                    <li>HELP response messages on request</li>
+                </ul>
+
+                <h2>4. Message and Data Rates</h2>
+                <p>
+                    Message and data rates may apply depending on your mobile plan and carrier.
+                </p>
+
+                <h2>5. How to Opt Out</h2>
+                <p>
+                    Reply with any supported keyword to stop messages: STOP, END, CANCEL, UNSUBSCRIBE, or QUIT.
+                    You will receive a final confirmation after opt-out.
+                </p>
+
+                <h2>6. How to Get Help</h2>
+                <p>
+                    Reply HELP or INFO to receive support details. You can also contact ByteStreams directly at
+                    <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a> or 629-282-9555.
+                </p>
+
+                <h2>7. Supported Carriers</h2>
+                <p>
+                    DialTone traffic uses registered 10DLC and is supported by major U.S. carriers. Carriers are not liable for
+                    delayed or undelivered messages.
+                </p>
+
+                <h2>8. Privacy and Data Sharing</h2>
+                <p>
+                    SMS opt-in data is not sold and is not shared with third parties for their marketing purposes.
+                    Data is shared only with necessary delivery providers and the restaurant receiving your order.
+                </p>
+
+                <h2>9. Eligibility</h2>
+                <p>
+                    SMS messaging is intended for recipients 18+ or otherwise legally able to consent under applicable law.
+                </p>
+
+                <h2>10. Recording and Retention</h2>
+                <p>
+                    Voice opt-ins are recorded and retained as proof of consent. Website opt-ins are logged with timestamp,
+                    IP address, and consent language.
+                </p>
+
+                <h2>11. Restaurant Responsibilities</h2>
+                <p>
+                    Restaurants using DialTone are responsible for messaging only users with valid consent. ByteStreams provides
+                    platform infrastructure and compliance tooling.
+                </p>
+
+                <h2>12. Updates to These Terms</h2>
+                <p>
+                    These terms may be updated to reflect legal, carrier, or platform changes. Continued use after updates
+                    constitutes acceptance.
+                </p>
+
+                <h2>13. Contact</h2>
+                <p>
+                    Questions about SMS terms or consent can be directed to ByteStreams at:
+                </p>
+                <ul>
+                    <li><strong>ByteStreams LLC</strong></li>
+                    <li>501 Union St Ste 545, Nashville, TN 37219</li>
+                    <li>Email: <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a></li>
+                    <li>Phone: <a href="tel:+16292829555">629-282-9555</a></li>
+                </ul>
+            </article>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="footer__container">
+            <div class="footer__grid">
+                <div class="footer__brand">
+                    <a href="index.html#home" class="footer__logo" aria-label="ByteStreams &mdash; home">
+                        <img src="assets/blue-side-slim-logo.png" alt="ByteStreams" width="198" height="56">
+                    </a>
+                    <p class="footer__tagline">Smarter Workflows, Stronger Results.</p>
+                </div>
+
+                <div class="footer__site-map" aria-label="Footer site links">
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Company</p>
+                        <ul class="footer__site-links">
+                            <li><a href="index.html#about" class="footer__link">About</a></li>
+                            <li><a href="#" class="footer__link">Security</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Product</p>
+                        <ul class="footer__site-links">
+                            <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="index.html#features" class="footer__link">Features</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Legal</p>
+                        <ul class="footer__site-links">
+                            <li><a href="privacy.html" class="footer__link">Privacy</a></li>
+                            <li><a href="terms.html" class="footer__link">Terms</a></li>
+                            <li><a href="sms-terms.html" class="footer__link">SMS Terms</a></li>
+                            <li><a href="cookies.html" class="footer__link">Cookie Policy</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <div class="footer__bottom">
+                <p class="footer__copyright">&copy; 2026 ByteStreams. Smarter Workflows, Stronger Results.</p>
+                <div class="footer__social" aria-label="Social links">
+                    <a href="#" class="footer__social-link" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in" aria-hidden="true"></i></a>
+                    <a href="#" class="footer__social-link" aria-label="X / Twitter"><i class="fa-brands fa-x-twitter" aria-hidden="true"></i></a>
+                    <a href="#" class="footer__social-link" aria-label="GitHub"><i class="fa-brands fa-github" aria-hidden="true"></i></a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -54,8 +54,245 @@
         <div class="section__container">
             <header class="section__header">
                 <h1 class="section__title">Terms &amp; Conditions</h1>
-                <p class="section__subtitle">Last updated: April 21, 2026</p>
+                <p class="section__subtitle">Last updated: April 22, 2026</p>
             </header>
+
+            <article class="legal-doc">
+
+                <h2>Agreement to Our Legal Terms</h2>
+
+                <p>
+                    We are bytestreams (<strong>&ldquo;Company,&rdquo;</strong> <strong>&ldquo;we,&rdquo;</strong>
+                    <strong>&ldquo;us,&rdquo;</strong> <strong>&ldquo;our&rdquo;</strong>), a company registered in Tennessee,
+                    United States at 501 Union St Ste 545, Nashville, TN 37219.
+                </p>
+
+                <p>
+                    We operate the website <a href="https://bytestreams.ai">https://bytestreams.ai</a> (the
+                    <strong>&ldquo;Site&rdquo;</strong>), as well as any other related products and services that refer or link
+                    to these legal terms (the <strong>&ldquo;Legal Terms&rdquo;</strong>) (collectively, the
+                    <strong>&ldquo;Services&rdquo;</strong>).
+                </p>
+
+                <p>We provide Agentic SaaS solutions and AI/ML Pipelines.</p>
+
+                <p>
+                    You can contact us by phone at 629-282-9555, email at
+                    <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a>, or by mail to 501 Union St Ste 545,
+                    Nashville, TN 37219, United States.
+                </p>
+
+                <p>
+                    These Legal Terms constitute a legally binding agreement made between you, whether personally or on behalf
+                    of an entity (<strong>&ldquo;you&rdquo;</strong>), and bytestreams, concerning your access to and use of
+                    the Services. You agree that by accessing the Services, you have read, understood, and agreed to be bound
+                    by all of these Legal Terms. IF YOU DO NOT AGREE WITH ALL OF THESE LEGAL TERMS, THEN YOU ARE EXPRESSLY
+                    PROHIBITED FROM USING THE SERVICES AND YOU MUST DISCONTINUE USE IMMEDIATELY.
+                </p>
+
+                <p>
+                    Supplemental terms and conditions or documents that may be posted on the Services from time to time are
+                    hereby expressly incorporated herein by reference. We reserve the right, in our sole discretion, to make
+                    changes or modifications to these Legal Terms at any time and for any reason. We will alert you about any
+                    changes by updating the &ldquo;Last updated&rdquo; date of these Legal Terms, and you waive any right to
+                    receive specific notice of each such change. It is your responsibility to periodically review these Legal
+                    Terms to stay informed of updates. You will be subject to, and will be deemed to have been made aware of
+                    and to have accepted, the changes in any revised Legal Terms by your continued use of the Services after
+                    the date such revised Legal Terms are posted.
+                </p>
+
+                <p>
+                    The Services are intended for users who are at least 18 years old. Persons under the age of 18 are not
+                    permitted to use or register for the Services.
+                </p>
+
+                <p>We recommend that you print a copy of these Legal Terms for your records.</p>
+
+                <h2>Table of Contents</h2>
+                <ol>
+                    <li><a href="#1-our-services">OUR SERVICES</a></li>
+                    <li><a href="#2-intellectual-property-rights">INTELLECTUAL PROPERTY RIGHTS</a></li>
+                    <li><a href="#3-user-representations">USER REPRESENTATIONS</a></li>
+                    <li><a href="#4-purchases-and-payment">PURCHASES AND PAYMENT</a></li>
+                    <li><a href="#5-subscriptions">SUBSCRIPTIONS</a></li>
+                    <li><a href="#6-prohibited-activities">PROHIBITED ACTIVITIES</a></li>
+                    <li><a href="#7-user-generated-contributions">USER GENERATED CONTRIBUTIONS</a></li>
+                    <li><a href="#8-contribution-license">CONTRIBUTION LICENSE</a></li>
+                    <li><a href="#9-third-party-websites-and-content">THIRD-PARTY WEBSITES AND CONTENT</a></li>
+                    <li><a href="#10-services-management">SERVICES MANAGEMENT</a></li>
+                    <li><a href="#11-privacy-policy">PRIVACY POLICY</a></li>
+                    <li><a href="#12-term-and-termination">TERM AND TERMINATION</a></li>
+                    <li><a href="#13-modifications-and-interruptions">MODIFICATIONS AND INTERRUPTIONS</a></li>
+                    <li><a href="#14-governing-law">GOVERNING LAW</a></li>
+                    <li><a href="#15-dispute-resolution">DISPUTE RESOLUTION</a></li>
+                    <li><a href="#16-corrections">CORRECTIONS</a></li>
+                    <li><a href="#17-disclaimer">DISCLAIMER</a></li>
+                    <li><a href="#18-limitations-of-liability">LIMITATIONS OF LIABILITY</a></li>
+                    <li><a href="#19-indemnification">INDEMNIFICATION</a></li>
+                    <li><a href="#20-user-data">USER DATA</a></li>
+                    <li><a href="#21-electronic-communications-transactions-and-signatures">ELECTRONIC COMMUNICATIONS, TRANSACTIONS, AND SIGNATURES</a></li>
+                    <li><a href="#22-sms-text-messaging">SMS TEXT MESSAGING</a></li>
+                    <li><a href="#23-california-users-and-residents">CALIFORNIA USERS AND RESIDENTS</a></li>
+                    <li><a href="#24-miscellaneous">MISCELLANEOUS</a></li>
+                    <li><a href="#25-contact-us">CONTACT US</a></li>
+                </ol>
+
+                <h2>1. Our Services</h2>
+                <p>
+                    The information provided when using the Services is not intended for distribution to or use by any person
+                    or entity in any jurisdiction or country where such distribution or use would be contrary to law or
+                    regulation or which would subject us to any registration requirement within such jurisdiction or country.
+                    Accordingly, those persons who choose to access the Services from other locations do so on their own
+                    initiative and are solely responsible for compliance with local laws, if and to the extent local laws are
+                    applicable.
+                </p>
+                <p>All SMS messaging operated by ByteStreams LLC is 10DLC Compliant.</p>
+
+                <h2>2. INTELLECTUAL PROPERTY RIGHTS</h2>
+                <h3>Our intellectual property</h3>
+                <p>We are the owner or the licensee of all intellectual property rights in our Services, including all source code, databases, functionality, software, website designs, audio, video, text, photographs, and graphics in the Services (collectively, the &quot;Content&quot;), as well as the trademarks, service marks, and logos contained therein (the &quot;Marks&quot;).</p>
+                <p>Our Content and Marks are protected by copyright and trademark laws (and various other intellectual property rights and unfair competition laws) and treaties in the United States and around the world.</p>
+                <p>The Content and Marks are provided in or through the Services &quot;AS IS&quot; for your internal business purpose only.</p>
+                <h3>Your use of our Services</h3>
+                <p>Subject to your compliance with these Legal Terms, including the &quot;<a href="#6-prohibited-activities">PROHIBITED ACTIVITIES</a>&quot; section below, we grant you a non-exclusive, non-transferable, revocable license to:</p>
+                <ul>
+                    <li>access the Services; and</li>
+                    <li>download or print a copy of any portion of the Content to which you have properly gained access,</li>
+                </ul>
+                <p>solely for your internal business purpose.</p>
+                <p>Except as set out in this section or elsewhere in our Legal Terms, no part of the Services and no Content or Marks may be copied, reproduced, aggregated, republished, uploaded, posted, publicly displayed, encoded, translated, transmitted, distributed, sold, licensed, or otherwise exploited for any commercial purpose whatsoever, without our express prior written permission.</p>
+                <p>If you wish to make any use of the Services, Content, or Marks other than as set out in this section or elsewhere in our Legal Terms, please address your request to: <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a>. If we ever grant you the permission to post, reproduce, or publicly display any part of our Services or Content, you must identify us as the owners or licensors of the Services, Content, or Marks and ensure that any copyright or proprietary notice appears or is visible on posting, reproducing, or displaying our Content.</p>
+                <p>We reserve all rights not expressly granted to you in and to the Services, Content, and Marks.</p>
+                <p>Any breach of these Intellectual Property Rights will constitute a material breach of our Legal Terms and your right to use our Services will terminate immediately.</p>
+                <h3>Your submissions</h3>
+                <p>Please review this section and the &quot;<a href="#6-prohibited-activities">PROHIBITED ACTIVITIES</a>&quot; section carefully prior to using our Services to understand the (a) rights you give us and (b) obligations you have when you post or upload any content through the Services.</p>
+                <p><strong>Submissions:</strong> By directly sending us any question, comment, suggestion, idea, feedback, or other information about the Services (&quot;Submissions&quot;), you agree to assign to us all intellectual property rights in such Submission. You agree that we shall own this Submission and be entitled to its unrestricted use and dissemination for any lawful purpose, commercial or otherwise, without acknowledgment or compensation to you.</p>
+                <p><strong>You are responsible for what you post or upload:</strong> By sending us Submissions through any part of the Services you:</p>
+                <ul>
+                    <li>confirm that you have read and agree with our &quot;<a href="#6-prohibited-activities">PROHIBITED ACTIVITIES</a>&quot; and will not post, send, publish, upload, or transmit through the Services any Submission that is illegal, harassing, hateful, harmful, defamatory, obscene, bullying, abusive, discriminatory, threatening to any person or group, sexually explicit, false, inaccurate, deceitful, or misleading;</li>
+                    <li>to the extent permissible by applicable law, waive any and all moral rights to any such Submission;</li>
+                    <li>warrant that any such Submission are original to you or that you have the necessary rights and licenses to submit such Submissions and that you have full authority to grant us the above-mentioned rights in relation to your Submissions; and</li>
+                    <li>warrant and represent that your Submissions do not constitute confidential information.</li>
+                </ul>
+                <p>You are solely responsible for your Submissions and you expressly agree to reimburse us for any and all losses that we may suffer because of your breach of (a) this section, (b) any third party&#39;s intellectual property rights, or (c) applicable law.</p>
+                <h2>3. USER REPRESENTATIONS</h2>
+                <p>By using the Services, you represent and warrant that: (1) you have the legal capacity and you agree to comply with these Legal Terms; (2) you are not a minor in the jurisdiction in which you reside; (3) you will not access the Services through automated or non-human means, whether through a bot, script or otherwise; (4) you will not use the Services for any illegal or unauthorized purpose; and (5) your use of the Services will not violate any applicable law or regulation.</p>
+                <p>If you provide any information that is untrue, inaccurate, not current, or incomplete, we have the right to suspend or terminate your account and refuse any and all current or future use of the Services (or any portion thereof).</p>
+                <h2>4. PURCHASES AND PAYMENT</h2>
+                <p>We accept the following forms of payment:</p>
+                <ul>
+                    <li>Visa</li>
+                    <li>Mastercard</li>
+                    <li>American Express</li>
+                    <li>PayPal</li>
+                    <li>Wire Transfer</li>
+                </ul>
+                <p>You agree to provide current, complete, and accurate purchase and account information for all purchases made via the Services. You further agree to promptly update account and payment information, including email address, payment method, and payment card expiration date, so that we can complete your transactions and contact you as needed. Sales tax will be added to the price of purchases as deemed required by us. We may change prices at any time. All payments shall be in US dollars.</p>
+                <p>You agree to pay all charges at the prices then in effect for your purchases and any applicable shipping fees, and you authorize us to charge your chosen payment provider for any such amounts upon placing your order. We reserve the right to correct any errors or mistakes in pricing, even if we have already requested or received payment.</p>
+                <p>We reserve the right to refuse any order placed through the Services. We may, in our sole discretion, limit or cancel quantities purchased per person, per household, or per order. These restrictions may include orders placed by or under the same customer account, the same payment method, and/or orders that use the same billing or shipping address. We reserve the right to limit or prohibit orders that, in our sole judgment, appear to be placed by dealers, resellers, or distributors.</p>
+                <h2>5. SUBSCRIPTIONS</h2>
+                <h3>Billing and Renewal</h3>
+                <hr>
+                <h3>Free Trial</h3>
+                <p>We offer a __________-day free trial to new users who register with the Services. The account will be charged according to the user&#39;s chosen subscription at the end of the free trial.</p>
+                <h3>Cancellation</h3>
+                <p>All purchases are non-refundable. You can cancel your subscription at any time by contacting us using the contact information provided below. Your cancellation will take effect at the end of the current paid term. If you have any questions or are unsatisfied with our Services, please email us at <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a>.</p>
+                <h3>Fee Changes</h3>
+                <p>We may, from time to time, make changes to the subscription fee and will communicate any price changes to you in accordance with applicable law.</p>
+                <h2>6. PROHIBITED ACTIVITIES</h2>
+                <p>You may not access or use the Services for any purpose other than that for which we make the Services available. The Services may not be used in connection with any commercial endeavors except those that are specifically endorsed or approved by us.</p>
+                <p>As a user of the Services, you agree not to:</p>
+                <ul>
+                    <li>Systematically retrieve data or other content from the Services to create or compile, directly or indirectly, a collection, compilation, database, or directory without written permission from us.</li>
+                    <li>Trick, defraud, or mislead us and other users, especially in any attempt to learn sensitive account information such as user passwords.</li>
+                    <li>Circumvent, disable, or otherwise interfere with security-related features of the Services, including features that prevent or restrict the use or copying of any Content or enforce limitations on the use of the Services and/or the Content contained therein.</li>
+                    <li>Disparage, tarnish, or otherwise harm, in our opinion, us and/or the Services.</li>
+                    <li>Use any information obtained from the Services in order to harass, abuse, or harm another person.</li>
+                    <li>Make improper use of our support services or submit false reports of abuse or misconduct.</li>
+                    <li>Use the Services in a manner inconsistent with any applicable laws or regulations.</li>
+                    <li>Engage in unauthorized framing of or linking to the Services.</li>
+                    <li>Upload or transmit (or attempt to upload or to transmit) viruses, Trojan horses, or other material, including excessive use of capital letters and spamming (continuous posting of repetitive text), that interferes with any party&#39;s uninterrupted use and enjoyment of the Services or modifies, impairs, disrupts, alters, or interferes with the use, features, functions, operation, or maintenance of the Services.</li>
+                    <li>Engage in any automated use of the system, such as using scripts to send comments or messages, or using any data mining, robots, or similar data gathering and extraction tools.</li>
+                    <li>Delete the copyright or other proprietary rights notice from any Content.</li>
+                    <li>Attempt to impersonate another user or person or use the username of another user.</li>
+                    <li>Upload or transmit (or attempt to upload or to transmit) any material that acts as a passive or active information collection or transmission mechanism, including without limitation, clear graphics interchange formats (&quot;gifs&quot;), 1×1 pixels, web bugs, cookies, or other similar devices (sometimes referred to as &quot;spyware&quot; or &quot;passive collection mechanisms&quot; or &quot;pcms&quot;).</li>
+                    <li>Interfere with, disrupt, or create an undue burden on the Services or the networks or services connected to the Services.</li>
+                    <li>Harass, annoy, intimidate, or threaten any of our employees or agents engaged in providing any portion of the Services to you.</li>
+                    <li>Attempt to bypass any measures of the Services designed to prevent or restrict access to the Services, or any portion of the Services.</li>
+                    <li>Copy or adapt the Services&#39; software, including but not limited to Flash, PHP, HTML, JavaScript, or other code.</li>
+                    <li>Except as permitted by applicable law, decipher, decompile, disassemble, or reverse engineer any of the software comprising or in any way making up a part of the Services.</li>
+                    <li>Except as may be the result of standard search engine or Internet browser usage, use, launch, develop, or distribute any automated system, including without limitation, any spider, robot, cheat utility, scraper, or offline reader that accesses the Services, or use or launch any unauthorized script or other software.</li>
+                    <li>Use a buying agent or purchasing agent to make purchases on the Services.</li>
+                    <li>Make any unauthorized use of the Services, including collecting usernames and/or email addresses of users by electronic or other means for the purpose of sending unsolicited email, or creating user accounts by automated means or under false pretenses.</li>
+                    <li>Use the Services as part of any effort to compete with us or otherwise use the Services and/or the Content for any revenue-generating endeavor or commercial enterprise.</li>
+                    <li>Use Service for purchasing, schedule appointments and cancellations, and answer business related questions.</li>
+                </ul>
+                <h2>7. USER GENERATED CONTRIBUTIONS</h2>
+                <p>The Services does not offer users to submit or post content.</p>
+                <h2>8. CONTRIBUTION LICENSE</h2>
+                <p>You and Services agree that we may access, store, process, and use any information and personal data that you provide following the terms of the Privacy Policy and your choices (including settings).</p>
+                <p>By submitting suggestions or other feedback regarding the Services, you agree that we can use and share such feedback for any purpose without compensation to you.</p>
+                <h2>9. THIRD-PARTY WEBSITES AND CONTENT</h2>
+                <p>The Services may contain (or you may be sent via the Site) links to other websites (&quot;Third-Party Websites&quot;) as well as articles, photographs, text, graphics, pictures, designs, music, sound, video, information, applications, software, and other content or items belonging to or originating from third parties (&quot;Third-Party Content&quot;). Such Third-Party Websites and Third-Party Content are not investigated, monitored, or checked for accuracy, appropriateness, or completeness by us, and we are not responsible for any Third-Party Websites accessed through the Services or any Third-Party Content posted on, available through, or installed from the Services, including the content, accuracy, offensiveness, opinions, reliability, privacy practices, or other policies of or contained in the Third-Party Websites or the Third-Party Content. Inclusion of, linking to, or permitting the use or installation of any Third-Party Websites or any Third-Party Content does not imply approval or endorsement thereof by us. If you decide to leave the Services and access the Third-Party Websites or to use or install any Third-Party Content, you do so at your own risk, and you should be aware these Legal Terms no longer govern. You should review the applicable terms and policies, including privacy and data gathering practices, of any website to which you navigate from the Services or relating to any applications you use or install from the Services. Any purchases you make through Third-Party Websites will be through other websites and from other companies, and we take no responsibility whatsoever in relation to such purchases which are exclusively between you and the applicable third party. You agree and acknowledge that we do not endorse the products or services offered on Third-Party Websites and you shall hold us blameless from any harm caused by your purchase of such products or services. Additionally, you shall hold us blameless from any losses sustained by you or harm caused to you relating to or resulting in any way from any Third-Party Content or any contact with Third-Party Websites.</p>
+                <h2>10. SERVICES MANAGEMENT</h2>
+                <p>We reserve the right, but not the obligation, to: (1) monitor the Services for violations of these Legal Terms; (2) take appropriate legal action against anyone who, in our sole discretion, violates the law or these Legal Terms, including without limitation, reporting such user to law enforcement authorities; (3) in our sole discretion and without limitation, refuse, restrict access to, limit the availability of, or disable (to the extent technologically feasible) any of your Contributions or any portion thereof; (4) in our sole discretion and without limitation, notice, or liability, to remove from the Services or otherwise disable all files and content that are excessive in size or are in any way burdensome to our systems; and (5) otherwise manage the Services in a manner designed to protect our rights and property and to facilitate the proper functioning of the Services.</p>
+                <h2>11. PRIVACY POLICY</h2>
+                <p>We care about data privacy and security. Please review our Privacy Policy: <a href="http://www.bytestreams.ai/cookies.html">http://www.bytestreams.ai/cookies.html</a>. By using the Services, you agree to be bound by our Privacy Policy, which is incorporated into these Legal Terms. Please be advised the Services are hosted in the United States. If you access the Services from any other region of the world with laws or other requirements governing personal data collection, use, or disclosure that differ from applicable laws in the United States, then through your continued use of the Services, you are transferring your data to the United States, and you expressly consent to have your data transferred to and processed in the United States.</p>
+                <h2>12. TERM AND TERMINATION</h2>
+                <p>These Legal Terms shall remain in full force and effect while you use the Services. WITHOUT LIMITING ANY OTHER PROVISION OF THESE LEGAL TERMS, WE RESERVE THE RIGHT TO, IN OUR SOLE DISCRETION AND WITHOUT NOTICE OR LIABILITY, DENY ACCESS TO AND USE OF THE SERVICES (INCLUDING BLOCKING CERTAIN IP ADDRESSES), TO ANY PERSON FOR ANY REASON OR FOR NO REASON, INCLUDING WITHOUT LIMITATION FOR BREACH OF ANY REPRESENTATION, WARRANTY, OR COVENANT CONTAINED IN THESE LEGAL TERMS OR OF ANY APPLICABLE LAW OR REGULATION. WE MAY TERMINATE YOUR USE OR PARTICIPATION IN THE SERVICES OR DELETE ANY CONTENT OR INFORMATION THAT YOU POSTED AT ANY TIME, WITHOUT WARNING, IN OUR SOLE DISCRETION.</p>
+                <p>If we terminate or suspend your account for any reason, you are prohibited from registering and creating a new account under your name, a fake or borrowed name, or the name of any third party, even if you may be acting on behalf of the third party. In addition to terminating or suspending your account, we reserve the right to take appropriate legal action, including without limitation pursuing civil, criminal, and injunctive redress.</p>
+                <h2>13. MODIFICATIONS AND INTERRUPTIONS</h2>
+                <p>We reserve the right to change, modify, or remove the contents of the Services at any time or for any reason at our sole discretion without notice. However, we have no obligation to update any information on our Services. We will not be liable to you or any third party for any modification, price change, suspension, or discontinuance of the Services.</p>
+                <p>We cannot guarantee the Services will be available at all times. We may experience hardware, software, or other problems or need to perform maintenance related to the Services, resulting in interruptions, delays, or errors. We reserve the right to change, revise, update, suspend, discontinue, or otherwise modify the Services at any time or for any reason without notice to you. You agree that we have no liability whatsoever for any loss, damage, or inconvenience caused by your inability to access or use the Services during any downtime or discontinuance of the Services. Nothing in these Legal Terms will be construed to obligate us to maintain and support the Services or to supply any corrections, updates, or releases in connection therewith.</p>
+                <h2>14. GOVERNING LAW</h2>
+                <p>These Legal Terms and your use of the Services are governed by and construed in accordance with the laws of the State of Tennessee applicable to agreements made and to be entirely performed within the State of Tennessee, without regard to its conflict of law principles.</p>
+                <h2>15. DISPUTE RESOLUTION</h2>
+                <h3>Informal Negotiations</h3>
+                <p>To expedite resolution and control the cost of any dispute, controversy, or claim related to these Legal Terms (each a &quot;Dispute&quot; and collectively, the &quot;Disputes&quot;) brought by either you or us (individually, a &quot;Party&quot; and collectively, the &quot;Parties&quot;), the Parties agree to first attempt to negotiate any Dispute (except those Disputes expressly provided below) informally for at least thirty (30) days before initiating arbitration. Such informal negotiations commence upon written notice from one Party to the other Party.</p>
+                <h3>Binding Arbitration</h3>
+                <p>Any dispute arising out of or in connection with these Legal Terms, including any question regarding its existence, validity, or termination, shall be referred to and finally resolved by the International Commercial Arbitration Court under the European Arbitration Chamber (Belgium, Brussels, Avenue Louise, 146) according to the Rules of this ICAC, which, as a result of referring to it, is considered as the part of this clause. The number of arbitrators shall be __________. The seat, or legal place, or arbitration shall be __________. The language of the proceedings shall be __________. The governing law of these Legal Terms shall be substantive law of __________.</p>
+                <h3>Restrictions</h3>
+                <p>The Parties agree that any arbitration shall be limited to the Dispute between the Parties individually. To the full extent permitted by law, (a) no arbitration shall be joined with any other proceeding; (b) there is no right or authority for any Dispute to be arbitrated on a class-action basis or to utilize class action procedures; and (c) there is no right or authority for any Dispute to be brought in a purported representative capacity on behalf of the general public or any other persons.</p>
+                <h3>Exceptions to Informal Negotiations and Arbitration</h3>
+                <p>The Parties agree that the following Disputes are not subject to the above provisions concerning informal negotiations binding arbitration: (a) any Disputes seeking to enforce or protect, or concerning the validity of, any of the intellectual property rights of a Party; (b) any Dispute related to, or arising from, allegations of theft, piracy, invasion of privacy, or unauthorized use; and (c) any claim for injunctive relief. If this provision is found to be illegal or unenforceable, then neither Party will elect to arbitrate any Dispute falling within that portion of this provision found to be illegal or unenforceable and such Dispute shall be decided by a court of competent jurisdiction within the courts listed for jurisdiction above, and the Parties agree to submit to the personal jurisdiction of that court.</p>
+                <h2>16. CORRECTIONS</h2>
+                <p>There may be information on the Services that contains typographical errors, inaccuracies, or omissions, including descriptions, pricing, availability, and various other information. We reserve the right to correct any errors, inaccuracies, or omissions and to change or update the information on the Services at any time, without prior notice.</p>
+                <h2>17. DISCLAIMER</h2>
+                <p>THE SERVICES ARE PROVIDED ON AN AS-IS AND AS-AVAILABLE BASIS. YOU AGREE THAT YOUR USE OF THE SERVICES WILL BE AT YOUR SOLE RISK. TO THE FULLEST EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, IN CONNECTION WITH THE SERVICES AND YOUR USE THEREOF, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE MAKE NO WARRANTIES OR REPRESENTATIONS ABOUT THE ACCURACY OR COMPLETENESS OF THE SERVICES&#39; CONTENT OR THE CONTENT OF ANY WEBSITES OR MOBILE APPLICATIONS LINKED TO THE SERVICES AND WE WILL ASSUME NO LIABILITY OR RESPONSIBILITY FOR ANY (1) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT AND MATERIALS, (2) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO AND USE OF THE SERVICES, (3) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION AND/OR FINANCIAL INFORMATION STORED THEREIN, (4) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICES, (5) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE WHICH MAY BE TRANSMITTED TO OR THROUGH THE SERVICES BY ANY THIRD PARTY, AND/OR (6) ANY ERRORS OR OMISSIONS IN ANY CONTENT AND MATERIALS OR FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT OF THE USE OF ANY CONTENT POSTED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE VIA THE SERVICES. WE DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED BY A THIRD PARTY THROUGH THE SERVICES, ANY HYPERLINKED WEBSITE, OR ANY WEBSITE OR MOBILE APPLICATION FEATURED IN ANY BANNER OR OTHER ADVERTISING, AND WE WILL NOT BE A PARTY TO OR IN ANY WAY BE RESPONSIBLE FOR MONITORING ANY TRANSACTION BETWEEN YOU AND ANY THIRD-PARTY PROVIDERS OF PRODUCTS OR SERVICES. AS WITH THE PURCHASE OF A PRODUCT OR SERVICE THROUGH ANY MEDIUM OR IN ANY ENVIRONMENT, YOU SHOULD USE YOUR BEST JUDGMENT AND EXERCISE CAUTION WHERE APPROPRIATE.</p>
+                <h2>18. LIMITATIONS OF LIABILITY</h2>
+                <p>IN NO EVENT WILL WE OR OUR DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY DIRECT, INDIRECT, CONSEQUENTIAL, EXEMPLARY, INCIDENTAL, SPECIAL, OR PUNITIVE DAMAGES, INCLUDING LOST PROFIT, LOST REVENUE, LOSS OF DATA, OR OTHER DAMAGES ARISING FROM YOUR USE OF THE SERVICES, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO YOU FOR ANY CAUSE WHATSOEVER AND REGARDLESS OF THE FORM OF THE ACTION, WILL AT ALL TIMES BE LIMITED TO $1,000.00 USD. CERTAIN US STATE LAWS AND INTERNATIONAL LAWS DO NOT ALLOW LIMITATIONS ON IMPLIED WARRANTIES OR THE EXCLUSION OR LIMITATION OF CERTAIN DAMAGES. IF THESE LAWS APPLY TO YOU, SOME OR ALL OF THE ABOVE DISCLAIMERS OR LIMITATIONS MAY NOT APPLY TO YOU, AND YOU MAY HAVE ADDITIONAL RIGHTS.</p>
+                <h2>19. INDEMNIFICATION</h2>
+                <p>You agree to defend, indemnify, and hold us harmless, including our subsidiaries, affiliates, and all of our respective officers, agents, partners, and employees, from and against any loss, damage, liability, claim, or demand, including reasonable attorneys&#39; fees and expenses, made by any third party due to or arising out of: (1) use of the Services; (2) breach of these Legal Terms; (3) any breach of your representations and warranties set forth in these Legal Terms; (4) your violation of the rights of a third party, including but not limited to intellectual property rights; or (5) any overt harmful act toward any other user of the Services with whom you connected via the Services. Notwithstanding the foregoing, we reserve the right, at your expense, to assume the exclusive defense and control of any matter for which you are required to indemnify us, and you agree to cooperate, at your expense, with our defense of such claims. We will use reasonable efforts to notify you of any such claim, action, or proceeding which is subject to this indemnification upon becoming aware of it.</p>
+                <h2>20. USER DATA</h2>
+                <p>We will maintain certain data that you transmit to the Services for the purpose of managing the performance of the Services, as well as data relating to your use of the Services. Although we perform regular routine backups of data, you are solely responsible for all data that you transmit or that relates to any activity you have undertaken using the Services. You agree that we shall have no liability to you for any loss or corruption of any such data, and you hereby waive any right of action against us arising from any such loss or corruption of such data.</p>
+                <h2>21. ELECTRONIC COMMUNICATIONS, TRANSACTIONS, AND SIGNATURES</h2>
+                <p>Visiting the Services, sending us emails, and completing online forms constitute electronic communications. You consent to receive electronic communications, and you agree that all agreements, notices, disclosures, and other communications we provide to you electronically, via email and on the Services, satisfy any legal requirement that such communication be in writing. YOU HEREBY AGREE TO THE USE OF ELECTRONIC SIGNATURES, CONTRACTS, ORDERS, AND OTHER RECORDS, AND TO ELECTRONIC DELIVERY OF NOTICES, POLICIES, AND RECORDS OF TRANSACTIONS INITIATED OR COMPLETED BY US OR VIA THE SERVICES. You hereby waive any rights or requirements under any statutes, regulations, rules, ordinances, or other laws in any jurisdiction which require an original signature or delivery or retention of non-electronic records, or to payments or the granting of credits by any means other than electronic means.</p>
+                <h2>22. SMS TEXT MESSAGING</h2>
+                <h3>Program Description</h3>
+                <p>By opting into any Customers Brand Name text messaging program, you expressly consent to receive text messages (SMS) to your mobile number. Customers Brand Name text messages may include: order updates.</p>
+                <h3>Message Frequency</h3>
+                <p>When you opt in to our SMS messaging service, you should expect to receive minimum of 3 SMS Messages. One to opt in to service, One to receive payment processing. One for payment confirmation. However there may be more when reservations, order changes, or marketing campaigns are involved.</p>
+                <h3>Opting Out</h3>
+                <p>If at any time you wish to stop receiving SMS messages from us, simply reply to the text with &quot;STOP.&quot; You may receive an SMS message confirming your opt out. After this, you will no longer receive SMS messages from us. If you want to join again, please sign up as you did the first time and we will start sending SMS messages to you again.</p>
+                <h3>Message and Data Rates</h3>
+                <p>Please be aware that message and data rates may apply to any SMS messages sent or received. The rates are determined by your carrier and the specifics of your mobile plan. Carriers are not liable for delayed or undelivered messages. If you have any questions about your text plan or data plan, contact your wireless provider.</p>
+                <h3>Support</h3>
+                <p>If you have any questions or need assistance regarding our SMS communications, please reply with the keyword HELP. You can also email us at <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a> or call at 629-282-9555. If you have any questions regarding privacy, please read our Privacy Policy: <a href="http://www.bytestreams.ai/cookies.html">http://www.bytestreams.ai/cookies.html</a>.</p>
+                <h2>23. CALIFORNIA USERS AND RESIDENTS</h2>
+                <p>If any complaint with us is not satisfactorily resolved, you can contact the Complaint Assistance Unit of the Division of Consumer Services of the California Department of Consumer Affairs in writing at 1625 North Market Blvd., Suite N 112, Sacramento, California 95834 or by telephone at (800) 952-5210 or (916) 445-1254.</p>
+                <h2>24. MISCELLANEOUS</h2>
+                <p>These Legal Terms and any policies or operating rules posted by us on the Services or in respect to the Services constitute the entire agreement and understanding between you and us. Our failure to exercise or enforce any right or provision of these Legal Terms shall not operate as a waiver of such right or provision. These Legal Terms operate to the fullest extent permissible by law. We may assign any or all of our rights and obligations to others at any time. We shall not be responsible or liable for any loss, damage, delay, or failure to act caused by any cause beyond our reasonable control. If any provision or part of a provision of these Legal Terms is determined to be unlawful, void, or unenforceable, that provision or part of the provision is deemed severable from these Legal Terms and does not affect the validity and enforceability of any remaining provisions. There is no joint venture, partnership, employment or agency relationship created between you and us as a result of these Legal Terms or use of the Services. You agree that these Legal Terms will not be construed against us by virtue of having drafted them. You hereby waive any and all defenses you may have based on the electronic form of these Legal Terms and the lack of signing by the parties hereto to execute these Legal Terms.</p>
+                <h2>25. CONTACT US</h2>
+                <p>In order to resolve a complaint regarding the Services or to receive further information regarding use of the Services, please contact us at:</p>
+                <p><strong>bytestreams</strong><br>
+                    501 Union St Ste 545<br>
+                    Nashville, TN 37219<br>
+                    United States<br>
+                    Phone: 629-282-9555<br>
+                    <a href="mailto:hello@bytestreams.ai">hello@bytestreams.ai</a>
+                </p>
+
+            </article>
         </div>
     </main>
 
@@ -72,28 +309,33 @@
                     </p>
                 </div>
 
-                <div>
-                    <p class="footer__column-title">Product</p>
-                    <ul class="footer__links">
-                        <li><a href="index.html#features" class="footer__link">Features</a></li>
-                    </ul>
-                </div>
+                <div class="footer__site-map" aria-label="Footer site links">
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Company</p>
+                        <ul class="footer__site-links">
+                            <li><a href="index.html#about" class="footer__link">About</a></li>
+                            <li><a href="#" class="footer__link">Security</a></li>
+                        </ul>
+                    </div>
 
-                <div>
-                    <p class="footer__column-title">Company</p>
-                    <ul class="footer__links">
-                        <li><a href="index.html#about" class="footer__link">About</a></li>
-                        <li><a href="#" class="footer__link">Security</a></li>
-                    </ul>
-                </div>
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Product</p>
+                        <ul class="footer__site-links">
+                            <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="index.html#features" class="footer__link">Features</a></li>
+                        </ul>
+                    </div>
 
-                <div>
-                    <p class="footer__column-title">Legal</p>
-                    <ul class="footer__links">
-                        <li><a href="privacy.html" class="footer__link">Privacy</a></li>
-                        <li><a href="terms.html" class="footer__link">Terms</a></li>
-                        <li><a href="#" class="footer__link">Cookie Policy</a></li>
-                    </ul>
+                    <div class="footer__site-row">
+                        <p class="footer__site-label">Legal</p>
+                        <ul class="footer__site-links">
+                            <li><a href="privacy.html" class="footer__link">Privacy</a></li>
+                            <li><a href="terms.html" class="footer__link">Terms</a></li>
+                            <li><a href="sms-terms.html" class="footer__link">SMS Terms</a></li>
+                            <li><a href="cookies.html" class="footer__link">Cookie Policy</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
chore(app): update footer links, terms copy, add sms-terms

Closes #7

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `sms-terms.html` and `cookies.html` legal pages, expands `privacy.html` and `terms.html` with full copy, and reworks the footer navigation across all pages into a row-based site map. The Sass/CSS changes are clean, but several legal documents ship with content errors that need resolving before the pages go live.

- **`privacy.html` (P1):** The new Privacy Notice reads "please do use our Services" on disagreement — missing "NOT" inverts the legal statement entirely; `[Company Address]` placeholder is also unfilled.
- **`terms.html` (P1):** §22 SMS section still contains the generic template text "Customers Brand Name" rather than ByteStreams/DialTone, which will flag immediately in carrier/10DLC review.
- **`cookies.html` (P1):** `[Company Address]` placeholder is unfilled in the contact block.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — multiple P1 issues remain across published legal documents.

Four P1 findings exist across privacy.html, terms.html, and cookies.html — an inverted legal statement, two unfilled address placeholders, and a "Customers Brand Name" template stub in the SMS consent section. Several P1 issues from prior review rounds also remain open. The footer restructuring and Sass changes are solid, but the legal pages are not production-ready.

privacy.html, terms.html, and cookies.html all require attention before merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| privacy.html | Substantially expanded with a full Privacy Notice; contains three copy errors: inverted legal statement ("please do use"), duplicated word ("may may"), heading typo ("DOWE"), and an unfilled [Company Address] placeholder. |
| terms.html | Expanded with full T&C content; §22 SMS section still contains unfilled "Customers Brand Name" template placeholder; previously flagged issues (§11/§22 privacy link points to cookies.html, §5/§15 blanks) remain unresolved. |
| cookies.html | New Cookie Policy page with correct content; contact block still contains unfilled [Company Address] placeholder; previously flagged ZIP code mismatch (38219) remains. |
| sms-terms.html | New SMS Terms & Consent page with clear consent language, opt-out keywords, and correct address (37219); content is well-structured for 10DLC compliance. |
| index.html | Footer reworked into row-based site map with new product and legal links; "comming soon" typo from previous review remains. |
| sass/layout/_footer.scss | Footer grid updated from 4-column to 2-column (brand + site-map); new BEM blocks for site-row, site-label, and site-links with arrow separators; responsive breakpoints updated correctly. |
| sass/base/_typography.scss | Added .legal-doc helper class for long-form legal content with appropriate spacing, list styling, and word-break for links; clean addition with no issues. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: privacy.html
Line: 70

Comment:
**Inverted legal statement — "please do use our Services"**

Line 70 reads "If you do not agree with our policies and practices, please do use our Services." The word "NOT" is missing, completely inverting the intended meaning. As-published, the Privacy Notice tells disagreeing users to proceed using the service, which is the opposite of what any standard privacy document should say.

```suggestion
                    is processed. If you do not agree with our policies and practices, please do not use our Services.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: privacy.html
Line: 109

Comment:
**Multiple copy errors — duplicated word and missing space in heading**

Two copy errors in the new Privacy Notice content:

1. Line 109: "privacy law may may mean" — the word "may" is duplicated.
2. Lines 127 and 158: the anchor/heading text reads "DOWE" instead of "DO WE" (missing space). This appears in both the table-of-contents `<a>` link (line 127) and the corresponding `<h2>` tag (line 158).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: privacy.html
Line: 332

Comment:
**Unfilled `[Company Address]` placeholder on published legal page**

The contact block at line 332 still contains `[Company Address]` rather than the actual mailing address. The same placeholder appears in `cookies.html` at line 123. Other pages (e.g. `terms.html`, `sms-terms.html`) correctly use "501 Union St Ste 545, Nashville, TN 37219". Publishing a Privacy Notice with a blank address field is legally incomplete and will look unfinished to users and regulators.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: terms.html
Line: 272-274

Comment:
**Template placeholder "Customers Brand Name" left in §22 SMS section**

The Program Description and Message Frequency paragraphs in §22 still contain the generic template text "Customers Brand Name" instead of "ByteStreams" or "DialTone". Users who read this section — including carrier reviewers during 10DLC vetting — will see an obviously unfilled template, undermining the legal validity of the consent language.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(app): update privacy, content update..."](https://github.com/bytes0211/bytestreams/commit/10434684047d18239addc7f3fef7979828b74b77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29298185)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->