### PR TITLE
PR - feat(contact, cloudflare): wire Get In Touch form to Worker API

### DIFF
--- a/github/ISSUES/implement-contact-form-worker-endpoint.md
+++ b/github/ISSUES/implement-contact-form-worker-endpoint.md
@@ -1,0 +1,97 @@
+# feat(contact, cloudflare): wire Get In Touch form to Worker API and email delivery
+
+## Summary
+
+The Get In Touch form currently validates on the client but does not deliver messages. This issue tracks implementing a server-side endpoint on the existing Cloudflare Worker so form submissions are processed and forwarded to the configured inbox.
+
+---
+
+## Problem
+
+The form in `index.html` appears functional but is not connected to a backend transport.
+
+Current behavior:
+- Required-field and email validation run in the browser.
+- Success text is shown after submit.
+- No request is sent to any server endpoint.
+
+Impact:
+- Visitor messages are silently dropped.
+- Contact intent is lost and cannot be recovered.
+
+---
+
+## Scope
+
+Implement and deploy a server-backed contact flow using existing infrastructure:
+- Add Worker endpoint `POST /api/contact`.
+- Validate and sanitize payload (`name`, `email`, `message`).
+- Add basic bot protection (honeypot field support).
+- Forward valid submissions to destination mailbox via FormSubmit.
+- Return structured JSON responses for success and failure states.
+- Update frontend form logic to submit to `/api/contact` and surface API errors.
+
+---
+
+## Implementation
+
+### Worker
+- New entry file: `worker.js`
+- Route handling:
+  - `POST /api/contact` -> process contact payload
+  - everything else -> `env.ASSETS.fetch(request)`
+- Behavior:
+  - Reject invalid JSON and invalid/missing fields (`400`).
+  - Return `503` if destination email binding is missing.
+  - Return `502` on upstream delivery failure.
+  - Return `200` JSON on success.
+
+### Frontend
+- File: `js/main.js`
+- Replace placeholder submit handler with async fetch to `/api/contact`.
+- Preserve client-side validation and improve UX states:
+  - "Sending your message..."
+  - success confirmation
+  - API error message display
+
+### Config
+- File: `wrangler.toml`
+- Add:
+  - `main = "worker.js"`
+  - `[vars] CONTACT_EMAIL = "hello@bytestreams.com"`
+
+---
+
+## Validation Performed
+
+- `npm run sass` completes successfully.
+- `npx wrangler deploy --config wrangler.toml --dry-run` succeeds and shows `CONTACT_EMAIL` binding.
+- Local endpoint tests via `wrangler dev`:
+  - invalid payload -> `400 Bad Request`
+  - valid payload -> `200 OK`
+
+---
+
+## Acceptance Criteria
+
+- Submitting the Get In Touch form sends a request to `/api/contact`.
+- Valid submissions return success and are forwarded to configured email destination.
+- Invalid payloads return clear error responses and user-visible form feedback.
+- Worker deploy remains compatible with static assets routing.
+
+---
+
+## Follow-up
+
+FormSubmit may require first-time mailbox activation for `hello@bytestreams.com`.
+Confirm activation email and complete provider verification to ensure live message delivery.
+
+---
+
+## Labels
+
+- `enhancement`
+- `cloudflare`
+- `contact-form`
+- `worker`
+- `ci/cd`

--- a/js/main.js
+++ b/js/main.js
@@ -135,7 +135,7 @@
   const status = $('#formStatus');
 
   if (form && status) {
-    form.addEventListener('submit', (e) => {
+    form.addEventListener('submit', async (e) => {
       e.preventDefault();
 
       const data = new FormData(form);
@@ -154,9 +154,28 @@
         return;
       }
 
-      // TODO: wire to real backend / form service.
-      setStatus('Thanks! We’ll get back to you shortly.', 'success');
-      form.reset();
+      setStatus('Sending your message...', 'success');
+
+      try {
+        const response = await fetch('/api/contact', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ name, email, message })
+        });
+
+        const payload = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          throw new Error(payload.error || 'Unable to send your message right now.');
+        }
+
+        setStatus('Thanks! We’ll get back to you shortly.', 'success');
+        form.reset();
+      } catch (err) {
+        setStatus(err.message || 'Unable to send your message right now.', 'error');
+      }
     });
 
     function setStatus(msg, kind) {

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,100 @@
+const JSON_HEADERS = {
+  'content-type': 'application/json; charset=utf-8'
+};
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/api/contact') {
+      return handleContact(request, env);
+    }
+
+    return env.ASSETS.fetch(request);
+  }
+};
+
+async function handleContact(request, env) {
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405);
+  }
+
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid request body' }, 400);
+  }
+
+  const name = normalizeText(payload.name, 120);
+  const email = normalizeText(payload.email, 254);
+  const message = normalizeText(payload.message, 5000);
+  const honeypot = normalizeText(payload.website || '', 200);
+
+  if (honeypot) {
+    return jsonResponse({ ok: true });
+  }
+
+  if (!name || !email || !message) {
+    return jsonResponse({ error: 'Please fill out all fields.' }, 400);
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return jsonResponse({ error: 'Please provide a valid email address.' }, 400);
+  }
+
+  const destinationEmail = env.CONTACT_EMAIL;
+  if (!destinationEmail) {
+    return jsonResponse({ error: 'Contact destination is not configured.' }, 503);
+  }
+
+  const result = await forwardToFormSubmit({
+    destinationEmail,
+    name,
+    email,
+    message,
+    origin: request.headers.get('origin') || 'unknown'
+  });
+
+  if (!result.ok) {
+    return jsonResponse({
+      error: 'Message delivery failed. Please try again shortly.'
+    }, 502);
+  }
+
+  return jsonResponse({ ok: true });
+}
+
+async function forwardToFormSubmit({ destinationEmail, name, email, message, origin }) {
+  const endpoint = `https://formsubmit.co/ajax/${encodeURIComponent(destinationEmail)}`;
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      name,
+      email,
+      message,
+      _subject: `ByteStreams Contact: ${name}`,
+      _captcha: 'false',
+      _template: 'table',
+      _source: `bytestreams.ai (${origin})`
+    })
+  });
+
+  return { ok: response.ok };
+}
+
+function normalizeText(value, maxLength) {
+  return String(value || '').trim().slice(0, maxLength);
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_HEADERS
+  });
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,8 +10,12 @@
 # (`bytestreams.ai`, `www.bytestreams.ai`) stay intact.
 
 name = "ancient-mountain-5dad"
+main = "worker.js"
 compatibility_date = "2026-04-21"
 compatibility_flags = []
+
+[vars]
+CONTACT_EMAIL = "hello@bytestreams.com"
 
 # Assets directory is the `public/` folder, which the GitHub Actions
 # workflow builds fresh on every deploy (copying only production files
@@ -23,3 +27,20 @@ directory = "./public"
 # SPA, so unknown paths should return 404 rather than rewriting to
 # /index.html.
 not_found_handling = "none"
+
+# Keep Worker observability settings in source control so dashboard and
+# CI/CD deployments stay consistent.
+[observability]
+enabled = false
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+persist = true
+head_sampling_rate = 1


### PR DESCRIPTION
feat(app)add get intouch email functinality

Closes #11

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the \"Get In Touch\" contact form to a new Cloudflare Worker endpoint (`POST /api/contact`) that validates input, checks a honeypot, and forwards submissions to FormSubmit for email delivery.

- **`forwardToFormSubmit` has no `try/catch`** — a network-level error (DNS failure, egress timeout) will throw an unhandled exception in the Worker instead of returning the intended 502 JSON response.
- **Honeypot is dead code** — the worker checks `payload.website`, but the frontend only serialises `{ name, email, message }`, so the field is never present and the guard can never fire.

<h3>Confidence Score: 3/5</h3>

Two P1 defects in worker.js should be fixed before this goes to production: an unhandled network error path and a non-functional honeypot.

The unhandled fetch exception in forwardToFormSubmit causes the Worker to crash ungracefully on any upstream network failure, and the honeypot bot-protection check is entirely bypassed because the frontend never sends the field. Both are present defects on the primary feature path introduced by this PR.

worker.js — unhandled network exception in forwardToFormSubmit and dead honeypot check.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker.js | New Cloudflare Worker handling POST /api/contact — missing try/catch in forwardToFormSubmit (unhandled network errors), honeypot check is dead code (field never sent by frontend), and CAPTCHA is explicitly disabled. |
| js/main.js | Form submit handler wired to /api/contact with async fetch; minor UX issue where 'success' CSS class is applied during in-flight 'Sending…' state before a potential error response. |
| wrangler.toml | Adds main entry point, CONTACT_EMAIL var, and observability config — straightforward and correct. |
| github/ISSUES/implement-contact-form-worker-endpoint.md | Issue tracking doc — no code changes, informational only. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker.js
Line: 68-88

Comment:
**Unhandled network error in `forwardToFormSubmit`**

`forwardToFormSubmit` makes an outbound `fetch` to FormSubmit but has no `try/catch`. If the external request fails (DNS error, connection reset, Worker egress timeout), the thrown `TypeError` will propagate up through `handleContact` as an unhandled exception, causing the Worker runtime to return a generic 500 with a plain-text body instead of the expected JSON. The client's `.catch(() => ({}))` will silently swallow the non-JSON response, but the Worker logs an uncaught error. Wrapping the call in a try/catch and returning a 502 on failure would be the safer path:

```js
async function forwardToFormSubmit({ ... }) {
  try {
    const response = await fetch(endpoint, { ... });
    return { ok: response.ok };
  } catch {
    return { ok: false };
  }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker.js
Line: 32-36

Comment:
**Honeypot field is never sent by the frontend**

The worker silently discards submissions where `payload.website` is truthy, but the frontend `fetch` only sends `{ name, email, message }` — the `website` field is never included in the JSON body. As a result, the honeypot check on line 34 can never trigger, and a bot submitting the API directly with no `website` key would also pass right through. The hidden field needs to be captured from the HTML form and forwarded in the request body for this guard to work.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: js/main.js
Line: 157

Comment:
**Wrong CSS class for the "sending" state**

`setStatus('Sending your message...', 'success')` applies the `form-status--success` class while the request is still in-flight. If the request then fails, `setStatus(err.message, 'error')` swaps it to `form-status--error`, but there's a noticeable flash of green/success styling before the red error appears. Consider using a neutral variant (e.g. `'info'` or `'pending'`) for the in-progress state to avoid this visual mismatch.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker.js
Line: 81-82

Comment:
**CAPTCHA explicitly disabled**

`_captcha: 'false'` tells FormSubmit to skip its own CAPTCHA challenge. With honeypot protection also non-functional (see above), the endpoint has no bot mitigation in place. Consider either re-enabling FormSubmit's CAPTCHA or adding a server-side rate-limit before production traffic lands on this endpoint.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(app)add get intouch email functinal..."](https://github.com/bytes0211/bytestreams/commit/92410e21f7c4e380785122578de24b2f24e2a814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29432527)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->