### PR TITLE
PR - fix(contact): restore Get In Touch email delivery

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,8 @@ jobs:
           # Fail fast if required legal pages are missing from the artifact.
           test -f public/cookies.html
           test -f public/sms-terms.html
+          # And the branded 404 page used by the Worker's `not_found_handling`.
+          test -f public/404.html
           # Strip sourcemaps from production (optional — remove if you want them)
           find public/dist -name '*.map' -delete || true
 

--- a/404.html
+++ b/404.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="ByteStreams Cookie Policy.">
+    <meta name="description" content="The page you were looking for could not be found on ByteStreams.">
     <meta name="theme-color" content="#0D1117">
-    <title>Cookie Policy &mdash; ByteStreams</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title>Page not found &mdash; ByteStreams</title>
 
     <link rel="icon" type="image/svg+xml" href="assets/bytestreams-icon-256.svg">
 
@@ -16,6 +17,40 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 
     <link rel="stylesheet" href="dist/css/main.css">
+
+    <style>
+        .not-found {
+            text-align: center;
+            padding: 32px 0 16px;
+        }
+        .not-found__eyebrow {
+            font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: 0.8125rem;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: var(--text-muted);
+            margin: 0 0 16px;
+        }
+        .not-found__mark {
+            font-family: 'Inter', system-ui, sans-serif;
+            font-weight: 700;
+            font-size: clamp(6rem, 18vw, 11rem);
+            line-height: 1;
+            letter-spacing: -0.04em;
+            background: linear-gradient(135deg, #2563EB 0%, #06B6D4 100%);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+            margin: 0 0 24px;
+        }
+        .not-found__actions {
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            justify-content: center;
+            margin-top: 32px;
+        }
+    </style>
 </head>
 <body data-theme="dark">
     <!-- ============== Header ============== -->
@@ -30,10 +65,10 @@
 
             <nav class="header__nav" id="primaryNav" aria-label="Primary">
                 <ul class="header__nav-list">
-                    <li><a href="index.html#home" class="header__nav-link">Home</a></li>
+                    <li><a href="index.html#home"     class="header__nav-link">Home</a></li>
                     <li><a href="index.html#features" class="header__nav-link">Features</a></li>
-                    <li><a href="index.html#about" class="header__nav-link">About</a></li>
-                    <li><a href="index.html#contact" class="header__nav-link">Contact</a></li>
+                    <li><a href="index.html#about"    class="header__nav-link">About</a></li>
+                    <li><a href="index.html#contact"  class="header__nav-link">Contact</a></li>
                 </ul>
             </nav>
 
@@ -52,79 +87,21 @@
     <!-- ============== Content ============== -->
     <main class="section">
         <div class="section__container">
+            <div class="not-found">
+                <p class="not-found__eyebrow">404 &middot; Page not found</p>
+                <p class="not-found__mark" aria-hidden="true">404</p>
+            </div>
             <header class="section__header">
-                <h1 class="section__title">Cookie Policy</h1>
-                <p class="section__subtitle">Last updated: April 22, 2026</p>
+                <h1 class="section__title">We can&rsquo;t find that page.</h1>
+                <p class="section__subtitle">
+                    It may have moved, been renamed, or never existed. The workflow is still flowing &mdash;
+                    pick one of these instead.
+                </p>
             </header>
-
-            <article class="legal-doc">
-                <p>
-                    This Cookie Policy explains how bytestreams (<strong>&quot;Company&quot;</strong>, <strong>&quot;we&quot;</strong>,
-                    <strong>&quot;us&quot;</strong>, and <strong>&quot;our&quot;</strong>) handles cookies and similar tracking technologies on
-                    <a href="https://bytestreams.ai">https://bytestreams.ai</a> (<strong>&quot;Website&quot;</strong>).
-                </p>
-
-                <p>
-                    <strong>Current status:</strong> We do <strong>not</strong> use cookies on this Website.
-                </p>
-
-                <h2>Do we use cookies?</h2>
-                <p>
-                    No. bytestreams.ai does not set first-party cookies, does not use third-party advertising cookies, and
-                    does not run cookie-based analytics.
-                </p>
-
-                <h2>Do we use similar tracking technologies?</h2>
-                <p>
-                    No. We do not use tracking pixels, web beacons, or browser fingerprinting technologies on this Website
-                    for advertising or behavioral tracking.
-                </p>
-
-                <h2>How does this align with our services?</h2>
-                <p>
-                    ByteStreams and related DialTone flows are primarily SMS-driven rather than browser-session-driven.
-                    Customer interactions are handled through phone and SMS channels, not cookie-based web user profiling.
-                </p>
-
-                <h2>What information do we collect on the Website?</h2>
-                <p>
-                    The Website may collect information you actively submit (for example, through contact forms or direct
-                    email communication). That collection is not cookie-based.
-                </p>
-
-                <h2>SMS and third-party providers</h2>
-                <p>
-                    SMS delivery for our product workflows may involve telecommunications providers (for example, Twilio)
-                    in operational systems. Those SMS operations are separate from cookie use on this Website and do not
-                    depend on cookies in your browser.
-                </p>
-
-                <h2>Do I need to change browser cookie settings?</h2>
-                <p>
-                    Since we do not use cookies on this Website, no cookie preference tool is required for bytestreams.ai
-                    at this time. You can still manage browser cookie settings globally if you prefer.
-                </p>
-
-                <h2>How often will this policy be updated?</h2>
-                <p>
-                    We may update this Cookie Policy if our practices change. If we begin using cookies or similar tracking
-                    technologies, we will update this page and revise the date shown at the top.
-                </p>
-
-                <h2>Where can I get more information?</h2>
-                <p>
-                    If you have questions about this Cookie Policy, please email us at
-                    <a href="mailto:privacy@bytestreams.com">privacy@bytestreams.com</a>.
-                </p>
-
-                <p>
-                    bytestreams LLC<br>
-                    Privacy Team<br>
-                    501 Union St Ste 545<br>
-                    Nashville, Tennessee 37219<br>
-                    US
-                </p>
-            </article>
+            <div class="not-found__actions">
+                <a href="index.html#home" class="btn btn--primary">Back to home</a>
+                <a href="index.html#contact" class="btn btn--outline">Contact</a>
+            </div>
         </div>
     </main>
 
@@ -183,7 +160,5 @@
             </div>
         </div>
     </footer>
-
-    <script src="js/main.js" defer></script>
 </body>
 </html>

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 *,
 *::before,
 *::after {
@@ -532,10 +533,15 @@ em {
   margin: 0;
   letter-spacing: 0.02em;
 }
+.footer__site-label::after {
+  content: "→";
+  color: var(--text-faded);
+  margin-left: 8px;
+}
 .footer__site-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -543,11 +549,6 @@ em {
 .footer__site-links li {
   display: inline-flex;
   align-items: center;
-}
-.footer__site-links li + li::before {
-  content: "->";
-  color: var(--text-faded);
-  margin-right: 8px;
 }
 .footer__bottom {
   border-top: 1px solid var(--border);

--- a/privacy.html
+++ b/privacy.html
@@ -329,7 +329,9 @@
                     Mailing Address:<br>
                     bytestreams LLC<br>
                     Privacy Team<br>
-                    [Company Address]
+                    501 Union St Ste 545<br>
+                    Nashville, Tennessee 37219<br>
+                    US
                 </p>
 
                 <p>

--- a/sass/layout/_footer.scss
+++ b/sass/layout/_footer.scss
@@ -106,12 +106,18 @@
     color: var(--text);
     margin: 0;
     letter-spacing: 0.02em;
+
+    &::after {
+      content: '\2192'; // right arrow (→)
+      color: var(--text-faded);
+      margin-left: $space-sm;
+    }
   }
 
   &__site-links {
     display: flex;
     flex-wrap: wrap;
-    gap: $space-sm;
+    gap: 10px; // slightly wider than $space-sm (8px) so links breathe
     margin: 0;
     padding: 0;
     list-style: none;
@@ -119,12 +125,6 @@
     li {
       display: inline-flex;
       align-items: center;
-    }
-
-    li + li::before {
-      content: '->';
-      color: var(--text-faded);
-      margin-right: $space-sm;
     }
   }
 

--- a/worker.js
+++ b/worker.js
@@ -6,13 +6,102 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
-    if (url.pathname === '/api/contact') {
-      return handleContact(request, env);
-    }
-
-    return env.ASSETS.fetch(request);
+    return routeRequest(request, env, url);
   }
 };
+
+async function routeRequest(request, env, url) {
+  if (url.pathname === '/robots.txt') {
+    return handleRobots();
+  }
+
+  if (url.pathname === '/favicon.ico') {
+    return handleFavicon(request, env);
+  }
+
+  if (url.pathname === '/.well-known/security.txt') {
+    return handleSecurityTxt();
+  }
+
+  if (url.pathname === '/sitemap.xml') {
+    return handleSitemap(url);
+  }
+
+  if (url.pathname === '/api/contact') {
+    return handleContact(request, env);
+  }
+
+  return env.ASSETS.fetch(request);
+}
+
+function handleRobots() {
+  const body = [
+    'User-agent: *',
+    'Allow: /',
+    'Disallow: /admin/',
+    'Disallow: /api/',
+    '',
+    'User-agent: GPTBot',
+    'Disallow: /',
+    '',
+    'Sitemap: https://bytestreams.ai/sitemap.xml',
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
+
+async function handleFavicon(request, env) {
+  // Browsers request `/favicon.ico` by default even when the HTML declares
+  // a different favicon (ours is the SVG icon in `/assets/`). Rewrite to
+  // the actual asset path so the tab icon still renders cleanly.
+  const faviconUrl = new URL(request.url);
+  faviconUrl.pathname = '/assets/bytestreams-icon-256.svg';
+  const faviconRequest = new Request(faviconUrl.toString(), request);
+  return env.ASSETS.fetch(faviconRequest);
+}
+
+function handleSecurityTxt() {
+  const body = [
+    'Contact: mailto:security@bytestreams.ai',
+    'Expires: 2027-04-23T00:00:00.000Z',
+    'Preferred-Languages: en',
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
+
+function handleSitemap(url) {
+  const pages = [
+    '/',
+    '/privacy.html',
+    '/terms.html',
+    '/sms-terms.html',
+    '/cookies.html'
+  ];
+  const body = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...pages.map((path) => `  <url><loc>${escapeXml(`${url.origin}${path}`)}</loc></url>`),
+    '</urlset>',
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'application/xml; charset=utf-8'
+    }
+  });
+}
 
 async function handleContact(request, env) {
   if (request.method !== 'POST') {
@@ -90,6 +179,15 @@ async function forwardToFormSubmit({ destinationEmail, name, email, message, ori
 
 function normalizeText(value, maxLength) {
   return String(value || '').trim().slice(0, maxLength);
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
 }
 
 function jsonResponse(body, status = 200) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,10 +23,27 @@ CONTACT_EMAIL = "hello@bytestreams.com"
 # package.json, etc.) never ship to the Worker.
 [assets]
 directory = "./public"
-# not_found_handling = "none" — this is a static multi-page site, not an
-# SPA, so unknown paths should return 404 rather than rewriting to
-# /index.html.
-not_found_handling = "none"
+# `binding = "ASSETS"` exposes the assets collection to the Worker as
+# `env.ASSETS`, which `worker.js` uses to proxy `/favicon.ico` to the
+# ByteStreams icon asset and to resolve unmatched paths. Without this
+# binding, `env.ASSETS` is undefined and those fallbacks fail silently.
+binding = "ASSETS"
+# not_found_handling = "404-page" — this is a static multi-page site,
+# not an SPA, so unknown paths should return the branded /404.html
+# with a 404 status rather than rewriting to /index.html.
+not_found_handling = "404-page"
+# With `not_found_handling = "404-page"`, non-asset requests are
+# short-circuited to `/404.html` without invoking the Worker. The
+# Worker owns these dynamic paths (robots.txt, sitemap.xml, favicon
+# fallback, security.txt, contact form), so force them to run through
+# the Worker first instead of being treated as missing assets.
+run_worker_first = [
+  "/robots.txt",
+  "/sitemap.xml",
+  "/favicon.ico",
+  "/.well-known/*",
+  "/api/*"
+]
 
 # Keep Worker observability settings in source control so dashboard and
 # CI/CD deployments stay consistent.


### PR DESCRIPTION
chore(app): 404 error handling, robots.txt, cosmetic updates

Part of #14

Closes #13

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores contact form email delivery by adding an `ASSETS` binding and `run_worker_first` routes in `wrangler.toml`, which ensures the Worker intercepts `/api/contact` before Cloudflare's new `404-page` handler can short-circuit the request. It also adds a branded `404.html`, dynamic route handlers for `robots.txt`, `sitemap.xml`, `favicon.ico`, and `security.txt` in `worker.js`, replaces placeholder company addresses in the legal pages, and refines the footer separator styling.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are minor style/maintenance concerns with no impact on runtime correctness.

The core fix (ASSETS binding + run_worker_first) is correctly wired; the new Worker route handlers are straightforward and the escapeXml helper is correct. Only P2 issues remain: a spelling typo and a hardcoded expiry date in security.txt.

worker.js — hardcoded Expires date in handleSecurityTxt will need manual updating before 2027-04-23.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker.js | Adds route handlers for robots.txt, favicon redirect, security.txt, and sitemap.xml; refactors routing into routeRequest; escapeXml helper is correct. One minor maintenance concern: hardcoded Expires in security.txt. |
| wrangler.toml | Adds ASSETS binding, switches not_found_handling to "404-page", and configures run_worker_first for dynamic paths — correctly enables the Worker to intercept /api/contact before the 404 handler fires, which is the real contact delivery fix. |
| 404.html | New branded 404 page with correct noindex meta tag and accessible markup; contains one spelling typo ("comming soon"). |
| .github/workflows/deploy.yml | Adds pre-deploy assertion that public/404.html is present in the artifact, matching the new not_found_handling setting. |
| sass/layout/_footer.scss | Moves separator arrow from li+li::before to footer__site-label::after and widens link gap to 10px; compiled CSS in dist/css/main.css matches. |
| privacy.html | Replaces [Company Address] placeholder with real mailing address. |
| cookies.html | Same placeholder address replacement as privacy.html. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: 404.html
Line: 134

Comment:
**Typo: "comming" → "coming"**

The footer link text for "DialTone.med" contains a spelling error that will be visible to users on every 404 page hit.

```suggestion
                            <li><a href="#" class="footer__link">DialTone.med (coming soon)</a></li>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker.js
Line: 79-86

Comment:
**Hardcoded `Expires` date will go stale**

The `security.txt` `Expires` field is set to a fixed date (`2027-04-23`). Per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116#section-2.5.5), this field must be updated before expiry or security researchers will treat the file as outdated. Consider deriving it dynamically (e.g., one year from `Date.now()`) so it never silently expires.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(app): 404 error handling, robots.t..."](https://github.com/bytes0211/bytestreams/commit/0ec1f109f820bf6d689a1ef51030aea13f5bdd44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29638041)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->