### PR TITLE
PR - Add branded 404, robots.txt, sitemap.xml, and Worker dynamic-route handling; footer/address polish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,8 @@ jobs:
           # Fail fast if required legal pages are missing from the artifact.
           test -f public/cookies.html
           test -f public/sms-terms.html
+          # And the branded 404 page used by the Worker's `not_found_handling`.
+          test -f public/404.html
           # Strip sourcemaps from production (optional — remove if you want them)
           find public/dist -name '*.map' -delete || true
 

--- a/404.html
+++ b/404.html
@@ -131,7 +131,7 @@
                         <p class="footer__site-label">Product</p>
                         <ul class="footer__site-links">
                             <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
-                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (coming soon)</a></li>
                             <li><a href="index.html#features" class="footer__link">Features</a></li>
                         </ul>
                     </div>

--- a/404.html
+++ b/404.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="ByteStreams Cookie Policy.">
+    <meta name="description" content="The page you were looking for could not be found on ByteStreams.">
     <meta name="theme-color" content="#0D1117">
-    <title>Cookie Policy &mdash; ByteStreams</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title>Page not found &mdash; ByteStreams</title>
 
     <link rel="icon" type="image/svg+xml" href="assets/bytestreams-icon-256.svg">
 
@@ -16,6 +17,40 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 
     <link rel="stylesheet" href="dist/css/main.css">
+
+    <style>
+        .not-found {
+            text-align: center;
+            padding: 32px 0 16px;
+        }
+        .not-found__eyebrow {
+            font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: 0.8125rem;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: var(--text-muted);
+            margin: 0 0 16px;
+        }
+        .not-found__mark {
+            font-family: 'Inter', system-ui, sans-serif;
+            font-weight: 700;
+            font-size: clamp(6rem, 18vw, 11rem);
+            line-height: 1;
+            letter-spacing: -0.04em;
+            background: linear-gradient(135deg, #2563EB 0%, #06B6D4 100%);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+            margin: 0 0 24px;
+        }
+        .not-found__actions {
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            justify-content: center;
+            margin-top: 32px;
+        }
+    </style>
 </head>
 <body data-theme="dark">
     <!-- ============== Header ============== -->
@@ -30,10 +65,10 @@
 
             <nav class="header__nav" id="primaryNav" aria-label="Primary">
                 <ul class="header__nav-list">
-                    <li><a href="index.html#home" class="header__nav-link">Home</a></li>
+                    <li><a href="index.html#home"     class="header__nav-link">Home</a></li>
                     <li><a href="index.html#features" class="header__nav-link">Features</a></li>
-                    <li><a href="index.html#about" class="header__nav-link">About</a></li>
-                    <li><a href="index.html#contact" class="header__nav-link">Contact</a></li>
+                    <li><a href="index.html#about"    class="header__nav-link">About</a></li>
+                    <li><a href="index.html#contact"  class="header__nav-link">Contact</a></li>
                 </ul>
             </nav>
 
@@ -52,79 +87,21 @@
     <!-- ============== Content ============== -->
     <main class="section">
         <div class="section__container">
+            <div class="not-found">
+                <p class="not-found__eyebrow">404 &middot; Page not found</p>
+                <p class="not-found__mark" aria-hidden="true">404</p>
+            </div>
             <header class="section__header">
-                <h1 class="section__title">Cookie Policy</h1>
-                <p class="section__subtitle">Last updated: April 22, 2026</p>
+                <h1 class="section__title">We can&rsquo;t find that page.</h1>
+                <p class="section__subtitle">
+                    It may have moved, been renamed, or never existed. The workflow is still flowing &mdash;
+                    pick one of these instead.
+                </p>
             </header>
-
-            <article class="legal-doc">
-                <p>
-                    This Cookie Policy explains how bytestreams (<strong>&quot;Company&quot;</strong>, <strong>&quot;we&quot;</strong>,
-                    <strong>&quot;us&quot;</strong>, and <strong>&quot;our&quot;</strong>) handles cookies and similar tracking technologies on
-                    <a href="https://bytestreams.ai">https://bytestreams.ai</a> (<strong>&quot;Website&quot;</strong>).
-                </p>
-
-                <p>
-                    <strong>Current status:</strong> We do <strong>not</strong> use cookies on this Website.
-                </p>
-
-                <h2>Do we use cookies?</h2>
-                <p>
-                    No. bytestreams.ai does not set first-party cookies, does not use third-party advertising cookies, and
-                    does not run cookie-based analytics.
-                </p>
-
-                <h2>Do we use similar tracking technologies?</h2>
-                <p>
-                    No. We do not use tracking pixels, web beacons, or browser fingerprinting technologies on this Website
-                    for advertising or behavioral tracking.
-                </p>
-
-                <h2>How does this align with our services?</h2>
-                <p>
-                    ByteStreams and related DialTone flows are primarily SMS-driven rather than browser-session-driven.
-                    Customer interactions are handled through phone and SMS channels, not cookie-based web user profiling.
-                </p>
-
-                <h2>What information do we collect on the Website?</h2>
-                <p>
-                    The Website may collect information you actively submit (for example, through contact forms or direct
-                    email communication). That collection is not cookie-based.
-                </p>
-
-                <h2>SMS and third-party providers</h2>
-                <p>
-                    SMS delivery for our product workflows may involve telecommunications providers (for example, Twilio)
-                    in operational systems. Those SMS operations are separate from cookie use on this Website and do not
-                    depend on cookies in your browser.
-                </p>
-
-                <h2>Do I need to change browser cookie settings?</h2>
-                <p>
-                    Since we do not use cookies on this Website, no cookie preference tool is required for bytestreams.ai
-                    at this time. You can still manage browser cookie settings globally if you prefer.
-                </p>
-
-                <h2>How often will this policy be updated?</h2>
-                <p>
-                    We may update this Cookie Policy if our practices change. If we begin using cookies or similar tracking
-                    technologies, we will update this page and revise the date shown at the top.
-                </p>
-
-                <h2>Where can I get more information?</h2>
-                <p>
-                    If you have questions about this Cookie Policy, please email us at
-                    <a href="mailto:privacy@bytestreams.com">privacy@bytestreams.com</a>.
-                </p>
-
-                <p>
-                    bytestreams LLC<br>
-                    Privacy Team<br>
-                    501 Union St Ste 545<br>
-                    Nashville, Tennessee 37219<br>
-                    US
-                </p>
-            </article>
+            <div class="not-found__actions">
+                <a href="index.html#home" class="btn btn--primary">Back to home</a>
+                <a href="index.html#contact" class="btn btn--outline">Contact</a>
+            </div>
         </div>
     </main>
 
@@ -183,7 +160,5 @@
             </div>
         </div>
     </footer>
-
-    <script src="js/main.js" defer></script>
 </body>
 </html>

--- a/cookies.html
+++ b/cookies.html
@@ -154,7 +154,7 @@
                         <p class="footer__site-label">Product</p>
                         <ul class="footer__site-links">
                             <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
-                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (coming soon)</a></li>
                             <li><a href="index.html#features" class="footer__link">Features</a></li>
                         </ul>
                     </div>

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 *,
 *::before,
 *::after {
@@ -532,10 +533,15 @@ em {
   margin: 0;
   letter-spacing: 0.02em;
 }
+.footer__site-label::after {
+  content: "→";
+  color: var(--text-faded);
+  margin-left: 8px;
+}
 .footer__site-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -543,11 +549,6 @@ em {
 .footer__site-links li {
   display: inline-flex;
   align-items: center;
-}
-.footer__site-links li + li::before {
-  content: "->";
-  color: var(--text-faded);
-  margin-right: 8px;
 }
 .footer__bottom {
   border-top: 1px solid var(--border);

--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@ US</p>
                         <p class="footer__site-label">Product</p>
                         <ul class="footer__site-links">
                             <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
-                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (coming soon)</a></li>
                             <li><a href="#features" class="footer__link">Features</a></li>
                         </ul>
                     </div>

--- a/privacy.html
+++ b/privacy.html
@@ -329,7 +329,9 @@
                     Mailing Address:<br>
                     bytestreams LLC<br>
                     Privacy Team<br>
-                    [Company Address]
+                    501 Union St Ste 545<br>
+                    Nashville, Tennessee 37219<br>
+                    US
                 </p>
 
                 <p>

--- a/privacy.html
+++ b/privacy.html
@@ -385,7 +385,7 @@
                         <p class="footer__site-label">Product</p>
                         <ul class="footer__site-links">
                             <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
-                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (coming soon)</a></li>
                             <li><a href="index.html#features" class="footer__link">Features</a></li>
                         </ul>
                     </div>

--- a/sass/layout/_footer.scss
+++ b/sass/layout/_footer.scss
@@ -106,12 +106,18 @@
     color: var(--text);
     margin: 0;
     letter-spacing: 0.02em;
+
+    &::after {
+      content: '\2192'; // right arrow (→)
+      color: var(--text-faded);
+      margin-left: $space-sm;
+    }
   }
 
   &__site-links {
     display: flex;
     flex-wrap: wrap;
-    gap: $space-sm;
+    gap: 10px; // slightly wider than $space-sm (8px) so links breathe
     margin: 0;
     padding: 0;
     list-style: none;
@@ -119,12 +125,6 @@
     li {
       display: inline-flex;
       align-items: center;
-    }
-
-    li + li::before {
-      content: '->';
-      color: var(--text-faded);
-      margin-right: $space-sm;
     }
   }
 

--- a/sms-terms.html
+++ b/sms-terms.html
@@ -178,7 +178,7 @@
                         <p class="footer__site-label">Product</p>
                         <ul class="footer__site-links">
                             <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
-                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (coming soon)</a></li>
                             <li><a href="index.html#features" class="footer__link">Features</a></li>
                         </ul>
                     </div>

--- a/terms.html
+++ b/terms.html
@@ -322,7 +322,7 @@
                         <p class="footer__site-label">Product</p>
                         <ul class="footer__site-links">
                             <li><a href="https://dialtone.menu" class="footer__link">DialTone.menu</a></li>
-                            <li><a href="#" class="footer__link">DialTone.med (comming soon)</a></li>
+                            <li><a href="#" class="footer__link">DialTone.med (coming soon)</a></li>
                             <li><a href="index.html#features" class="footer__link">Features</a></li>
                         </ul>
                     </div>

--- a/worker.js
+++ b/worker.js
@@ -6,13 +6,102 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
-    if (url.pathname === '/api/contact') {
-      return handleContact(request, env);
-    }
-
-    return env.ASSETS.fetch(request);
+    return routeRequest(request, env, url);
   }
 };
+
+async function routeRequest(request, env, url) {
+  if (url.pathname === '/robots.txt') {
+    return handleRobots();
+  }
+
+  if (url.pathname === '/favicon.ico') {
+    return handleFavicon(request, env);
+  }
+
+  if (url.pathname === '/.well-known/security.txt') {
+    return handleSecurityTxt();
+  }
+
+  if (url.pathname === '/sitemap.xml') {
+    return handleSitemap(url);
+  }
+
+  if (url.pathname === '/api/contact') {
+    return handleContact(request, env);
+  }
+
+  return env.ASSETS.fetch(request);
+}
+
+function handleRobots() {
+  const body = [
+    'User-agent: *',
+    'Allow: /',
+    'Disallow: /admin/',
+    'Disallow: /api/',
+    '',
+    'User-agent: GPTBot',
+    'Disallow: /',
+    '',
+    'Sitemap: https://bytestreams.ai/sitemap.xml',
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
+
+async function handleFavicon(request, env) {
+  // Browsers request `/favicon.ico` by default even when the HTML declares
+  // a different favicon (ours is the SVG icon in `/assets/`). Rewrite to
+  // the actual asset path so the tab icon still renders cleanly.
+  const faviconUrl = new URL(request.url);
+  faviconUrl.pathname = '/assets/bytestreams-icon-256.svg';
+  const faviconRequest = new Request(faviconUrl.toString(), request);
+  return env.ASSETS.fetch(faviconRequest);
+}
+
+function handleSecurityTxt() {
+  const body = [
+    'Contact: mailto:security@bytestreams.ai',
+    'Expires: 2027-04-23T00:00:00.000Z',
+    'Preferred-Languages: en',
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
+
+function handleSitemap(url) {
+  const pages = [
+    '/',
+    '/privacy.html',
+    '/terms.html',
+    '/sms-terms.html',
+    '/cookies.html'
+  ];
+  const body = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...pages.map((path) => `  <url><loc>${escapeXml(`${url.origin}${path}`)}</loc></url>`),
+    '</urlset>',
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'application/xml; charset=utf-8'
+    }
+  });
+}
 
 async function handleContact(request, env) {
   if (request.method !== 'POST') {
@@ -90,6 +179,15 @@ async function forwardToFormSubmit({ destinationEmail, name, email, message, ori
 
 function normalizeText(value, maxLength) {
   return String(value || '').trim().slice(0, maxLength);
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
 }
 
 function jsonResponse(body, status = 200) {

--- a/worker.js
+++ b/worker.js
@@ -12,7 +12,7 @@ export default {
 
 async function routeRequest(request, env, url) {
   if (url.pathname === '/robots.txt') {
-    return handleRobots();
+    return handleRobots(url);
   }
 
   if (url.pathname === '/favicon.ico') {
@@ -34,7 +34,10 @@ async function routeRequest(request, env, url) {
   return env.ASSETS.fetch(request);
 }
 
-function handleRobots() {
+function handleRobots(url) {
+  // Build the Sitemap URL from `url.origin` so the directive is correct
+  // on any deployment (preview, staging, production) — matches the
+  // pattern in `handleSitemap` for consistency.
   const body = [
     'User-agent: *',
     'Allow: /',
@@ -44,7 +47,7 @@ function handleRobots() {
     'User-agent: GPTBot',
     'Disallow: /',
     '',
-    'Sitemap: https://bytestreams.ai/sitemap.xml',
+    `Sitemap: ${url.origin}/sitemap.xml`,
     ''
   ].join('\n');
 

--- a/worker.js
+++ b/worker.js
@@ -137,15 +137,33 @@ async function handleContact(request, env) {
     return jsonResponse({ error: 'Contact destination is not configured.' }, 503);
   }
 
-  const result = await forwardToFormSubmit({
+  if (!env.RESEND_API_KEY) {
+    // Surfaces in observability; client-side error keeps submitters in
+    // the form rather than bouncing them to a mail app.
+    console.log('Contact form unavailable: RESEND_API_KEY secret is not set.');
+    return jsonResponse({
+      error: 'Contact form is temporarily unavailable. Please try again shortly.'
+    }, 503);
+  }
+
+  const result = await forwardToResend({
     destinationEmail,
     name,
     email,
     message,
-    origin: request.headers.get('origin') || 'unknown'
+    apiKey: env.RESEND_API_KEY
   });
 
   if (!result.ok) {
+    // Log provider response for CF Workers observability — rate-limit
+    // reasons, invalid-key errors, and domain-unverified states all
+    // surface here. Details stay server-side.
+    console.log('Resend failure:', JSON.stringify({
+      httpStatus: result.httpStatus,
+      errorName: result.errorName,
+      errorMessage: result.errorMessage
+    }));
+
     return jsonResponse({
       error: 'Message delivery failed. Please try again shortly.'
     }, 502);
@@ -154,27 +172,90 @@ async function handleContact(request, env) {
   return jsonResponse({ ok: true });
 }
 
-async function forwardToFormSubmit({ destinationEmail, name, email, message, origin }) {
-  const endpoint = `https://formsubmit.co/ajax/${encodeURIComponent(destinationEmail)}`;
-
-  const response = await fetch(endpoint, {
+async function forwardToResend({ destinationEmail, name, email, message, apiKey }) {
+  const response = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
       Accept: 'application/json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
     },
     body: JSON.stringify({
-      name,
-      email,
-      message,
-      _subject: `ByteStreams Contact: ${name}`,
-      _captcha: 'false',
-      _template: 'table',
-      _source: `bytestreams.ai (${origin})`
+      // Sender lives on the verified `send.bytestreams.ai` Resend domain
+      // (shared with DialTone; verified 2026-04-24).
+      from: `ByteStreams <contact@send.bytestreams.ai>`,
+      to: [destinationEmail],
+      // Reply-To: submitter's address, as a single-element array to
+      // match Resend's documented canonical form. The regex check
+      // upstream in `handleContact` rejects display-name / bracketed
+      // syntax (whitespace and `<>` fail the anchored
+      // `[^\s@]+@[^\s@]+\.[^\s@]+` pattern), so `email` is a bare address.
+      reply_to: [email],
+      subject: `ByteStreams Contact: ${name}`,
+      text: buildTextBody({ name, email, message }),
+      html: buildHtmlBody({ name, email, message })
     })
   });
 
-  return { ok: response.ok };
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  // Resend success returns `{ id: "<resend_message_id>" }`; errors return
+  // `{ statusCode, name, message }`. Treat presence of `id` as the ok signal.
+  const ok = response.ok && payload !== null && typeof payload.id === 'string';
+
+  return {
+    ok,
+    httpStatus: response.status,
+    errorName: payload && payload.name ? String(payload.name) : '',
+    errorMessage: payload && payload.message ? String(payload.message) : ''
+  };
+}
+
+function buildTextBody({ name, email, message }) {
+  return [
+    'New ByteStreams contact form submission',
+    '',
+    `From: ${name} <${email}>`,
+    '',
+    message,
+    '',
+    '---',
+    'Submitted via the ByteStreams contact form.',
+    'Reply directly to this email to respond to the sender.'
+  ].join('\n');
+}
+
+function buildHtmlBody({ name, email, message }) {
+  const safeName = escapeHtml(name);
+  const safeEmail = escapeHtml(email);
+  const safeMessage = escapeHtml(message);
+  return [
+    '<!doctype html>',
+    '<html>',
+    '<body style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #0D1117;">',
+    '<h2 style="margin: 0 0 16px 0;">New ByteStreams contact form submission</h2>',
+    `<p style="margin: 0 0 8px 0;"><strong>From:</strong> ${safeName} &lt;<a href="mailto:${safeEmail}" style="color: #2563EB;">${safeEmail}</a>&gt;</p>`,
+    '<hr style="border: none; border-top: 1px solid #d0d7de; margin: 16px 0;">',
+    `<div style="white-space: pre-wrap; line-height: 1.5;">${safeMessage}</div>`,
+    '<hr style="border: none; border-top: 1px solid #d0d7de; margin: 24px 0 16px 0;">',
+    '<p style="margin: 0; font-size: 12px; color: #6b7280;">Submitted via the ByteStreams contact form. Reply directly to this email to respond to the sender.</p>',
+    '</body>',
+    '</html>'
+  ].join('');
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }
 
 function normalizeText(value, maxLength) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -23,10 +23,27 @@ CONTACT_EMAIL = "hello@bytestreams.com"
 # package.json, etc.) never ship to the Worker.
 [assets]
 directory = "./public"
-# not_found_handling = "none" — this is a static multi-page site, not an
-# SPA, so unknown paths should return 404 rather than rewriting to
-# /index.html.
-not_found_handling = "none"
+# `binding = "ASSETS"` exposes the assets collection to the Worker as
+# `env.ASSETS`, which `worker.js` uses to proxy `/favicon.ico` to the
+# ByteStreams icon asset and to resolve unmatched paths. Without this
+# binding, `env.ASSETS` is undefined and those fallbacks fail silently.
+binding = "ASSETS"
+# not_found_handling = "404-page" — this is a static multi-page site,
+# not an SPA, so unknown paths should return the branded /404.html
+# with a 404 status rather than rewriting to /index.html.
+not_found_handling = "404-page"
+# With `not_found_handling = "404-page"`, non-asset requests are
+# short-circuited to `/404.html` without invoking the Worker. The
+# Worker owns these dynamic paths (robots.txt, sitemap.xml, favicon
+# fallback, security.txt, contact form), so force them to run through
+# the Worker first instead of being treated as missing assets.
+run_worker_first = [
+  "/robots.txt",
+  "/sitemap.xml",
+  "/favicon.ico",
+  "/.well-known/*",
+  "/api/*"
+]
 
 # Keep Worker observability settings in source control so dashboard and
 # CI/CD deployments stay consistent.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,8 +14,25 @@ main = "worker.js"
 compatibility_date = "2026-04-21"
 compatibility_flags = []
 
+# Contact form destination. The Worker's `/api/contact` handler sends
+# validated submissions via Resend's API; messages are delivered here.
+# `hello@bytestreams.ai` is the monitored inbox (Cloudflare Email Routing
+# forwards it to scotton's Workspace). Previously set to `.com` by
+# mistake — corrected during the Resend migration.
 [vars]
-CONTACT_EMAIL = "hello@bytestreams.com"
+CONTACT_EMAIL = "hello@bytestreams.ai"
+
+# Required secret (not stored in this file): RESEND_API_KEY
+# The `/api/contact` handler uses this to authenticate with Resend's
+# API. Set it once per environment via:
+#
+#   npx wrangler secret put RESEND_API_KEY
+#
+# The value is encrypted at rest by Cloudflare and exposed to the
+# Worker at runtime as `env.RESEND_API_KEY`. Never commit the raw key.
+# If the secret is missing, `/api/contact` returns a user-friendly 503
+# directing submitters to retry (no mailto fallback — keeps visitors
+# in the form rather than bouncing them to a mail app).
 
 # Assets directory is the `public/` folder, which the GitHub Actions
 # workflow builds fresh on every deploy (copying only production files


### PR DESCRIPTION
commit

chore(app): 404 error handling, robots.txt, cosmetic updates

Part of #14

Closes #17

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships a branded 404 page, dynamic `robots.txt`/`sitemap.xml`/`security.txt` handlers in the Cloudflare Worker, a favicon rewrite, and migrates the contact form from FormSubmit to Resend. It also fixes the previously hardcoded sitemap URL in `handleRobots` (now correctly derived from `url.origin`), adds the required `ASSETS` binding, switches `not_found_handling` to `"404-page"`, and uses `run_worker_first` to ensure dynamic routes are served by the Worker before static-asset fallback kicks in. Typo fixes and real mailing address data round out the cosmetic polish across all legal pages.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues found; all findings are minor P2 suggestions.

Prior review concerns (hardcoded sitemap URL in robots.txt, call-site mismatch) are fully resolved. HTML/XML escaping is correct, the Resend migration is well-guarded, and the wrangler config changes are consistent. Only two non-blocking P2 items remain: a hardcoded security.txt expiry and missing cache-control headers on synthetic text responses.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker.js | Major refactor: adds robots.txt, sitemap.xml, security.txt, and favicon-rewrite handlers; migrates contact form from FormSubmit to Resend with proper HTML/text body builders and server-side escaping. Two P2 suggestions: hardcoded security.txt expiry and missing cache-control headers. |
| wrangler.toml | Adds explicit ASSETS binding, switches not_found_handling to "404-page", adds run_worker_first for dynamic routes, corrects CONTACT_EMAIL domain (.com → .ai), and documents RESEND_API_KEY secret requirement. |
| 404.html | New branded 404 page with full header/footer, noindex meta tag, and gradient "404" display mark. Clean copy with no typos. |
| sass/layout/_footer.scss | Moves the arrow separator from li+li::before pseudo-element to __site-label::after, making it a column header decoration rather than an inter-item separator. |
| .github/workflows/deploy.yml | Adds test assertion for 404.html presence in the artifact before deploying, ensuring the branded 404 page is always shipped. |
| dist/css/main.css | Compiled CSS reflecting footer SCSS changes: adds charset declaration, moves arrow to label::after, removes li+li::before rule, adjusts gap from 8px to 10px. |
| cookies.html | Replaces "[Company Address]" placeholder with a real mailing address and fixes the "comming" typo in the footer. |
| privacy.html | Same address and typo fixes as cookies.html. |
| index.html | Fixes "comming" → "coming" typo in the footer product list. |
| sms-terms.html | Fixes "comming" → "coming" typo in footer. |
| terms.html | Fixes "comming" → "coming" typo in footer. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker.js
Line: 74

Comment:
**Hardcoded `security.txt` expiry needs manual renewal**

The `Expires` date is a static string that will become stale in ~1 year. RFC 9116 requires the file to be considered untrusted after this date, so crawlers and security researchers will stop trusting it. A comment (or a computed date) would make the renewal requirement explicit.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker.js
Line: 54-58

Comment:
**No cache-control headers on synthetic text responses**

`handleRobots`, `handleSitemap`, and `handleSecurityTxt` all return responses without a `Cache-Control` header. Without it, Cloudflare may fall back to its default heuristic TTL, and every cache miss hits the Worker. Adding an explicit header (e.g., `max-age=3600, s-maxage=86400`) would cut unnecessary Worker invocations and make caching behavior predictable across environments.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(app) site updates"](https://github.com/bytes0211/bytestreams/commit/de217b42134062348ced5a29aa408d24a3ff7576) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29674760)</sub>

<!-- /greptile_comment -->