### PR TITLE
PR - fix(contact): restore Get In Touch email delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ public/
 
 # Wrangler local state
 .wrangler/
+
+# Local secrets for Wrangler dev
+.dev.vars

--- a/README.md
+++ b/README.md
@@ -44,6 +44,31 @@ npm run serve               # python3 -m http.server 8000
 
 Open `http://localhost:8000`.
 
+### Test contact/email flow in local dev
+
+The contact form posts to the Worker endpoint (`/api/contact`), so use Worker
+dev mode for end-to-end email testing.
+
+```bash
+# one-time per machine: create .dev.vars with your key
+# RESEND_API_KEY=...
+
+npm run sass
+npm run dev:worker
+```
+
+Then open `http://127.0.0.1:8787` and submit the contact form.
+
+Quick API sanity check:
+
+```bash
+curl -i -X POST http://127.0.0.1:8787/api/contact \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Dev Test","email":"you@example.com","message":"Hello from dev"}'
+```
+
+Expected success is `200` with `{"ok":true}`.
+
 ### Production build
 
 ```bash

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -956,6 +956,15 @@ textarea.form-control {
   color: #EF4444;
 }
 
+.honeypot {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
 .section {
   padding: 64px 0;
 }

--- a/github/ISSUES/fix-contact-resend-delivery-and-worker-alignment.md
+++ b/github/ISSUES/fix-contact-resend-delivery-and-worker-alignment.md
@@ -1,0 +1,93 @@
+# fix(contact, cloudflare): restore Resend delivery and align Worker email flow with DialTone
+
+## Summary
+
+Production contact submissions returned `503` and did not deliver email because the deployed Cloudflare Worker was missing the `RESEND_API_KEY` secret.
+
+This issue tracks the operational restore plus the code/config alignment work that brought ByteStreams' email flow in line with the DialTone Worker template.
+
+---
+
+## Problem
+
+The ByteStreams contact form posted to `POST /api/contact`, but live submissions failed with:
+
+- `{"error":"Contact form is temporarily unavailable. Please try again shortly."}`
+
+Impact:
+
+- Visitors could submit the form, but no email was delivered.
+- Local testing and production behavior could drift when `public/` was stale or Worker secrets were missing.
+
+---
+
+## Root Cause
+
+Two issues combined:
+
+- The production Worker did not have `RESEND_API_KEY` configured, so `handleContact` returned `503` before calling Resend.
+- ByteStreams had drifted from the DialTone Worker template for email metadata and local dev workflow, which made verification less reliable.
+
+---
+
+## Fix Implemented
+
+### Operational restore
+
+- Uploaded `RESEND_API_KEY` to the production Worker via Wrangler secret management.
+
+### Worker/template alignment
+
+Updated `worker.js` to match the DialTone email implementation pattern:
+
+- Added normalized static asset fallback handling (`handleAssetRequest`, `notFoundResponse`).
+- Added `SITE_NAME`-driven email metadata for:
+  - `from`
+  - `subject`
+  - text body copy
+  - HTML body copy
+- Kept the existing ByteStreams routes and asset paths intact.
+
+### Local dev workflow hardening
+
+- Added `build:public` to rebuild the Worker asset directory from current source files.
+- Added `dev:worker` to rebuild `public/` and run `wrangler dev` in one command.
+- Documented local Worker-based email testing in `README.md`.
+- Ignored `.dev.vars` so local Resend credentials stay out of git.
+
+---
+
+## Files Changed
+
+- `.gitignore`
+- `README.md`
+- `package.json`
+- `worker.js`
+- `wrangler.toml`
+
+---
+
+## Validation
+
+- Local endpoint test returned `200 OK` from `http://127.0.0.1:8787/api/contact`.
+- Production endpoint initially returned `503` with the temporary-unavailable error.
+- After uploading the missing secret, production returned `200 OK` with `{"ok":true}` from `https://bytestreams.ai/api/contact`.
+
+---
+
+## Acceptance Criteria
+
+- Submitting the live ByteStreams contact form delivers through Resend again.
+- Production `POST /api/contact` returns `200` for a valid payload.
+- ByteStreams Worker email metadata follows the same `SITE_NAME` template pattern as DialTone.
+- Local dev testing uses the Worker path instead of a stale static-only server.
+
+---
+
+## Labels
+
+- `bug`
+- `cloudflare`
+- `contact-form`
+- `email`
+- `worker`

--- a/github/ISSUES/fix-get-in-touch-email-delivery.md
+++ b/github/ISSUES/fix-get-in-touch-email-delivery.md
@@ -1,0 +1,80 @@
+# fix(contact): restore Get In Touch email delivery to hello@bytestreams.ai
+
+## Summary
+
+Get In Touch submissions were failing in production after deployment. Users saw delivery errors and no messages arrived in the target inbox.
+
+This issue tracks the root cause analysis, remediation, and post-fix verification for the contact flow.
+
+---
+
+## Problem
+
+Production contact form submissions did not deliver email.
+
+Observed behavior:
+- Frontend displayed `Message delivery failed. Please try again shortly.`
+- No inbound messages at `hello@bytestreams.ai`
+
+---
+
+## Root Causes
+
+1. Destination mismatch:
+- Contact flow was configured to send to `hello@bytestreams.com` while business contact target is `hello@bytestreams.ai`.
+
+2. Provider activation state:
+- FormSubmit reported the `.ai` destination form as not activated until activation link was completed.
+
+3. Cached frontend asset:
+- Custom domain briefly served stale `js/main.js`, delaying rollout of destination updates.
+
+---
+
+## Fix Implemented
+
+### Contact destination alignment
+- Updated form endpoint destination from `.com` to `.ai` in `js/main.js`.
+- Updated contact display email in `index.html`.
+- Updated Worker config var in `wrangler.toml` to `.ai`.
+
+### User-facing failure messaging
+- Improved activation-state message in frontend so users/admins get actionable guidance while provider activation is pending.
+
+### Cache-busting rollout
+- Added version query string to script include in `index.html` and `public/index.html`:
+  - `js/main.js?v=20260423a`
+
+### Deploy + verification
+- Deployed updated assets and worker via Wrangler.
+- Confirmed production JS references:
+  - `https://formsubmit.co/ajax/hello@bytestreams.ai`
+- Confirmed provider success response after activation:
+  - `{"success":"true","message":"The form was submitted successfully."}`
+
+---
+
+## Files Touched
+
+- `js/main.js`
+- `index.html`
+- `public/index.html`
+- `wrangler.toml`
+
+---
+
+## Acceptance Criteria
+
+- Get In Touch submissions from `bytestreams.ai` return provider success.
+- Messages are delivered to `hello@bytestreams.ai`.
+- Production site serves updated contact script with `.ai` destination.
+
+---
+
+## Labels
+
+- `bug`
+- `contact-form`
+- `production`
+- `cloudflare`
+- `email`

--- a/index.html
+++ b/index.html
@@ -284,9 +284,14 @@ US</p>
                                       placeholder="Your message..." required></textarea>
                         </div>
 
+                        <div class="honeypot" aria-hidden="true">
+                            <label for="websiteField">Leave this field empty</label>
+                            <input id="websiteField" name="website" type="text" tabindex="-1" autocomplete="off">
+                        </div>
+
                         <p class="form-status" id="formStatus" role="status" aria-live="polite"></p>
 
-                        <button type="submit" class="btn btn--primary btn--block btn--lg">
+                        <button type="submit" id="submitBtn" class="btn btn--primary btn--block btn--lg">
                             Send Message
                         </button>
                     </form>

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
                             </span>
                             <div class="contact-info__body">
                                 <p class="contact-info__label">Email</p>
-                                <p class="contact-info__value">hello@bytestreams.com</p>
+                                <p class="contact-info__value">hello@bytestreams.ai</p>
                             </div>
                         </div>
 
@@ -351,6 +351,6 @@ US</p>
         </div>
     </footer>
 
-    <script src="js/main.js" defer></script>
+    <script src="js/main.js?v=20260423a" defer></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -135,6 +135,8 @@
   const status = $('#formStatus');
 
   if (form && status) {
+    const formEndpoint = 'https://formsubmit.co/ajax/hello@bytestreams.ai';
+
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
 
@@ -157,17 +159,31 @@
       setStatus('Sending your message...', 'success');
 
       try {
-        const response = await fetch('/api/contact', {
+        const response = await fetch(formEndpoint, {
           method: 'POST',
           headers: {
+            Accept: 'application/json',
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify({ name, email, message })
+          body: JSON.stringify({
+            name,
+            email,
+            message,
+            _subject: `ByteStreams Contact: ${name}`,
+            _captcha: 'false',
+            _template: 'table',
+            _source: window.location.origin
+          })
         });
 
         const payload = await response.json().catch(() => ({}));
+        const providerSuccess = payload && String(payload.success).toLowerCase() === 'true';
 
-        if (!response.ok) {
+        if (!response.ok || !providerSuccess) {
+          const needsActivation = String(payload.message || '').toLowerCase().includes('needs activation');
+          if (needsActivation) {
+            throw new Error('Contact form setup is pending activation. Please email hello@bytestreams.ai for now.');
+          }
           throw new Error(payload.error || 'Unable to send your message right now.');
         }
 

--- a/js/main.js
+++ b/js/main.js
@@ -130,13 +130,12 @@
     }
   }
 
-  // ---------- Contact form (client-side only feedback) ----------------
-  const form   = $('#contactForm');
-  const status = $('#formStatus');
+  // ---------- Contact form (posts to Worker at /api/contact) ----------
+  const form      = $('#contactForm');
+  const status    = $('#formStatus');
+  const submitBtn = $('#submitBtn');
 
   if (form && status) {
-    const formEndpoint = 'https://formsubmit.co/ajax/hello@bytestreams.ai';
-
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
 
@@ -144,46 +143,33 @@
       const name    = (data.get('name')    || '').toString().trim();
       const email   = (data.get('email')   || '').toString().trim();
       const message = (data.get('message') || '').toString().trim();
+      const website = (data.get('website') || '').toString().trim();
 
-      // Minimal validation
       if (!name || !email || !message) {
         setStatus('Please fill out all fields.', 'error');
         return;
       }
-      const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-      if (!emailOk) {
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
         setStatus('Please enter a valid email address.', 'error');
         return;
       }
 
+      if (submitBtn) submitBtn.disabled = true;
       setStatus('Sending your message...', 'success');
 
       try {
-        const response = await fetch(formEndpoint, {
+        const response = await fetch('/api/contact', {
           method: 'POST',
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify({
-            name,
-            email,
-            message,
-            _subject: `ByteStreams Contact: ${name}`,
-            _captcha: 'false',
-            _template: 'table',
-            _source: window.location.origin
-          })
+          body: JSON.stringify({ name, email, message, website })
         });
 
         const payload = await response.json().catch(() => ({}));
-        const providerSuccess = payload && String(payload.success).toLowerCase() === 'true';
 
-        if (!response.ok || !providerSuccess) {
-          const needsActivation = String(payload.message || '').toLowerCase().includes('needs activation');
-          if (needsActivation) {
-            throw new Error('Contact form setup is pending activation. Please email hello@bytestreams.ai for now.');
-          }
+        if (!response.ok || !payload.ok) {
           throw new Error(payload.error || 'Unable to send your message right now.');
         }
 
@@ -191,6 +177,8 @@
         form.reset();
       } catch (err) {
         setStatus(err.message || 'Unable to send your message right now.', 'error');
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "sass": "sass sass/main.scss dist/css/main.css",
     "sass:watch": "sass --watch sass/main.scss dist/css/main.css",
-    "serve": "python3 -m http.server 8000"
+    "serve": "python3 -m http.server 8000",
+    "build:public": "rm -rf public && mkdir -p public && cp *.html public/ && cp -r assets dist js public/ && find public/dist -name '*.map' -delete || true",
+    "dev:worker": "npm run build:public && wrangler dev --config wrangler.toml --port 8787"
   },
   "keywords": [
     "bytestreams",

--- a/sass/components/_contact-form.scss
+++ b/sass/components/_contact-form.scss
@@ -116,3 +116,12 @@ textarea.form-control {
   &--success { color: $color-success; }
   &--error   { color: $color-error; }
 }
+
+.honeypot {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/worker.js
+++ b/worker.js
@@ -240,12 +240,12 @@ async function forwardToResend({ destinationEmail, siteName, name, email, messag
       // (shared with DialTone; verified 2026-04-24).
       from: `${siteName} <contact@send.bytestreams.ai>`,
       to: [destinationEmail],
-      // Reply-To: submitter's address, as a single-element array to
-      // match Resend's documented canonical form. The regex check
-      // upstream in `handleContact` rejects display-name / bracketed
-      // syntax (whitespace and `<>` fail the anchored
-      // `[^
-\s@]+@[^\s@]+\.[^\s@]+` pattern), so `email` is a bare address.
+      // Reply-To: the submitter's address so hitting Reply in Gmail goes
+      // straight back to the person who filled out the form. Passed as a
+      // single-element array to match Resend's documented canonical form;
+      // the regex check in `handleContact` already rejects display-name /
+      // bracketed-address syntax (whitespace and `<>` fail the anchored
+      // `[^\s@]+@[^\s@]+\.[^\s@]+` pattern), so `email` is a bare address.
       reply_to: [email],
       subject: `${siteName} Contact: ${name}`,
       text: buildTextBody({ siteName, name, email, message }),

--- a/worker.js
+++ b/worker.js
@@ -14,6 +14,156 @@ export default {
   }
 };
 
+<<<<<<< Updated upstream
+=======
+async function routeRequest(request, env, url) {
+  // Explicit handlers for known dynamic paths.
+  if (url.pathname === '/robots.txt') {
+    return handleRobots(url);
+  }
+
+  if (url.pathname === '/favicon.ico') {
+    return handleFavicon(request, env);
+  }
+
+  if (url.pathname === '/.well-known/security.txt') {
+    return handleSecurityTxt();
+  }
+
+  if (url.pathname === '/sitemap.xml') {
+    return handleSitemap(url);
+  }
+
+  if (url.pathname === '/api/contact') {
+    return handleContact(request, env);
+  }
+
+  // For all paths not explicitly handled above, delegate to the assets binding
+  // and normalize missing lookups to 404.
+  return handleAssetRequest(request, env);
+}
+
+async function handleAssetRequest(request, env) {
+  try {
+    const response = await env.ASSETS.fetch(request);
+
+    // Missing static assets can surface as 500 from the assets binding;
+    // normalize those to 404 so crawlers and clients get the correct status.
+    if (response.status === 500 && isLookupMethod(request.method)) {
+      return notFoundResponse();
+    }
+
+    return response;
+  } catch (error) {
+    // If asset resolution throws on an unmatched path, return 404 rather
+    // than exposing an internal failure.
+    if (isLookupMethod(request.method)) {
+      console.log('ASSETS fetch lookup error:', String(error));
+      return notFoundResponse();
+    }
+
+    throw error;
+  }
+}
+
+function isLookupMethod(method) {
+  return method === 'GET' || method === 'HEAD';
+}
+
+function notFoundResponse() {
+  return new Response('Not Found', {
+    status: 404,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
+
+function handleRobots(url) {
+  // Build the Sitemap URL from `url.origin` so the directive is correct
+  // on any deployment (preview, staging, production) — matches the
+  // pattern in `handleSitemap` for consistency.
+  const body = [
+    'User-agent: *',
+    'Allow: /',
+    'Disallow: /admin/',
+    'Disallow: /api/',
+    '',
+    'User-agent: GPTBot',
+    'Disallow: /',
+    '',
+    `Sitemap: ${url.origin}/sitemap.xml`,
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
+
+async function handleFavicon(request, env) {
+  // Browsers request `/favicon.ico` by default even when the HTML declares
+  // a different favicon (ours is the SVG icon in `/assets/`). Rewrite to
+  // the actual asset path so the tab icon still renders cleanly.
+  const faviconUrl = new URL(request.url);
+  faviconUrl.pathname = '/assets/bytestreams-icon-256.svg';
+  const faviconRequest = new Request(faviconUrl.toString(), request);
+  try {
+    const response = await env.ASSETS.fetch(faviconRequest);
+    if (response.status === 500 && isLookupMethod(request.method)) {
+      return notFoundResponse();
+    }
+    return response;
+  } catch (error) {
+    if (isLookupMethod(request.method)) {
+      console.log('ASSETS favicon lookup error:', String(error));
+      return notFoundResponse();
+    }
+    throw error;
+  }
+}
+
+function handleSecurityTxt() {
+  const body = [
+    'Contact: mailto:security@bytestreams.ai',
+    'Expires: 2027-04-23T00:00:00.000Z',
+    'Preferred-Languages: en',
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8'
+    }
+  });
+}
+
+function handleSitemap(url) {
+  const pages = [
+    '/',
+    '/privacy.html',
+    '/terms.html',
+    '/sms-terms.html',
+    '/cookies.html'
+  ];
+  const body = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...pages.map((path) => `  <url><loc>${escapeXml(`${url.origin}${path}`)}</loc></url>`),
+    '</urlset>',
+    ''
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'application/xml; charset=utf-8'
+    }
+  });
+}
+
+>>>>>>> Stashed changes
 async function handleContact(request, env) {
   if (request.method !== 'POST') {
     return jsonResponse({ error: 'Method not allowed' }, 405);
@@ -53,6 +203,7 @@ async function handleContact(request, env) {
 
   const result = await forwardToFormSubmit({
     destinationEmail,
+    siteName: env.SITE_NAME,
     name,
     email,
     message,
@@ -77,10 +228,15 @@ async function handleContact(request, env) {
   return jsonResponse({ ok: true });
 }
 
+<<<<<<< Updated upstream
 async function forwardToFormSubmit({ destinationEmail, name, email, message, origin }) {
   const endpoint = `https://formsubmit.co/ajax/${encodeURIComponent(destinationEmail)}`;
 
   const response = await fetch(endpoint, {
+=======
+async function forwardToResend({ destinationEmail, siteName, name, email, message, apiKey }) {
+  const response = await fetch('https://api.resend.com/emails', {
+>>>>>>> Stashed changes
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -89,6 +245,7 @@ async function forwardToFormSubmit({ destinationEmail, name, email, message, ori
       Referer: `${origin}/`
     },
     body: JSON.stringify({
+<<<<<<< Updated upstream
       name,
       email,
       message,
@@ -96,6 +253,21 @@ async function forwardToFormSubmit({ destinationEmail, name, email, message, ori
       _captcha: 'false',
       _template: 'table',
       _source: `bytestreams.ai (${origin})`
+=======
+      // Sender lives on the verified `send.bytestreams.ai` Resend domain
+      // (shared with DialTone; verified 2026-04-24).
+      from: `${siteName} <contact@send.bytestreams.ai>`,
+      to: [destinationEmail],
+      // Reply-To: submitter's address, as a single-element array to
+      // match Resend's documented canonical form. The regex check
+      // upstream in `handleContact` rejects display-name / bracketed
+      // syntax (whitespace and `<>` fail the anchored
+      // `[^\s@]+@[^\s@]+\.[^\s@]+` pattern), so `email` is a bare address.
+      reply_to: [email],
+      subject: `${siteName} Contact: ${name}`,
+      text: buildTextBody({ siteName, name, email, message }),
+      html: buildHtmlBody({ siteName, name, email, message })
+>>>>>>> Stashed changes
     })
   });
 
@@ -114,6 +286,52 @@ async function forwardToFormSubmit({ destinationEmail, name, email, message, ori
   };
 }
 
+<<<<<<< Updated upstream
+=======
+function buildTextBody({ siteName, name, email, message }) {
+  return [
+    `New ${siteName} contact form submission`,
+    '',
+    `From: ${name} <${email}>`,
+    '',
+    message,
+    '',
+    '---',
+    `Submitted via the ${siteName} contact form.`,
+    'Reply directly to this email to respond to the sender.'
+  ].join('\n');
+}
+
+function buildHtmlBody({ siteName, name, email, message }) {
+  const safeSite = escapeHtml(siteName);
+  const safeName = escapeHtml(name);
+  const safeEmail = escapeHtml(email);
+  const safeMessage = escapeHtml(message);
+  return [
+    '<!doctype html>',
+    '<html>',
+    '<body style="font-family: -apple-system, BlinkMacSystemFont, \'Segoe UI\', sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #0D1117;">',
+    `<h2 style="margin: 0 0 16px 0;">New ${safeSite} contact form submission</h2>`,
+    `<p style="margin: 0 0 8px 0;"><strong>From:</strong> ${safeName} &lt;<a href="mailto:${safeEmail}" style="color: #2563EB;">${safeEmail}</a>&gt;</p>`,
+    '<hr style="border: none; border-top: 1px solid #d0d7de; margin: 16px 0;">',
+    `<div style="white-space: pre-wrap; line-height: 1.5;">${safeMessage}</div>`,
+    '<hr style="border: none; border-top: 1px solid #d0d7de; margin: 24px 0 16px 0;">',
+    `<p style="margin: 0; font-size: 12px; color: #6b7280;">Submitted via the ${safeSite} contact form. Reply directly to this email to respond to the sender.</p>`,
+    '</body>',
+    '</html>'
+  ].join('');
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+>>>>>>> Stashed changes
 function normalizeText(value, maxLength) {
   return String(value || '').trim().slice(0, maxLength);
 }

--- a/worker.js
+++ b/worker.js
@@ -48,15 +48,27 @@ async function handleContact(request, env) {
     return jsonResponse({ error: 'Contact destination is not configured.' }, 503);
   }
 
+  const requestUrl = new URL(request.url);
+  const requestOrigin = request.headers.get('origin') || requestUrl.origin;
+
   const result = await forwardToFormSubmit({
     destinationEmail,
     name,
     email,
     message,
-    origin: request.headers.get('origin') || 'unknown'
+    origin: requestOrigin
   });
 
   if (!result.ok) {
+    const providerMessage = (result.providerMessage || '').toLowerCase();
+    const needsActivation = providerMessage.includes('needs activation');
+
+    if (needsActivation) {
+      return jsonResponse({
+        error: 'Contact form setup is pending activation. Please email hello@bytestreams.com for now.'
+      }, 503);
+    }
+
     return jsonResponse({
       error: 'Message delivery failed. Please try again shortly.'
     }, 502);
@@ -72,7 +84,9 @@ async function forwardToFormSubmit({ destinationEmail, name, email, message, ori
     method: 'POST',
     headers: {
       Accept: 'application/json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      Origin: origin,
+      Referer: `${origin}/`
     },
     body: JSON.stringify({
       name,
@@ -85,7 +99,19 @@ async function forwardToFormSubmit({ destinationEmail, name, email, message, ori
     })
   });
 
-  return { ok: response.ok };
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  const providerSuccess = payload && String(payload.success).toLowerCase() === 'true';
+
+  return {
+    ok: response.ok && providerSuccess,
+    providerMessage: payload && payload.message ? String(payload.message) : ''
+  };
 }
 
 function normalizeText(value, maxLength) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,6 +16,7 @@ compatibility_flags = []
 
 [vars]
 CONTACT_EMAIL = "hello@bytestreams.ai"
+SITE_NAME = "ByteStreams"
 
 # Assets directory is the `public/` folder, which the GitHub Actions
 # workflow builds fresh on every deploy (copying only production files

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,7 +15,7 @@ compatibility_date = "2026-04-21"
 compatibility_flags = []
 
 [vars]
-CONTACT_EMAIL = "hello@bytestreams.com"
+CONTACT_EMAIL = "hello@bytestreams.ai"
 
 # Assets directory is the `public/` folder, which the GitHub Actions
 # workflow builds fresh on every deploy (copying only production files
@@ -30,17 +30,9 @@ not_found_handling = "none"
 
 # Keep Worker observability settings in source control so dashboard and
 # CI/CD deployments stay consistent.
-[observability]
-enabled = false
-head_sampling_rate = 1
-
 [observability.logs]
 enabled = true
-head_sampling_rate = 1
-persist = true
 invocation_logs = true
 
 [observability.traces]
 enabled = false
-persist = true
-head_sampling_rate = 1


### PR DESCRIPTION
Merge remote-tracking branch 'origin/main' into bug/send-email

# Conflicts:
#	worker.js
#	wrangler.toml

chore(app): clean up

fix(email): fix the get in touch email form

Closes #13

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores contact-form email delivery via the Cloudflare Worker/Resend path: the frontend now POSTs to `/api/contact` instead of FormSubmit, email addresses are corrected from `.com` to `.ai`, a honeypot field is wired up on both sides, and the submit button is properly disabled during the in-flight request. Local dev workflow is also hardened with `build:public` / `dev:worker` scripts and `.dev.vars` in `.gitignore`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no new P0/P1 issues found; all previously flagged concerns have been resolved or were already noted in prior threads.

The core bug fixes (Worker endpoint, email destination, honeypot) are correct. The only remaining feedback is a P2 UX nit about the in-flight status colour. Prior P1 concerns (FormSubmit bypass, SITE_NAME guard) were already raised in earlier review rounds.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker.js | Added honeypot server-side check, SITE_NAME-driven email metadata, and handleAssetRequest/notFoundResponse helpers. SITE_NAME is still unguarded (already noted in prior threads). |
| js/main.js | Form now correctly POSTs to /api/contact (Worker) instead of FormSubmit; honeypot field included in payload; submit button disabled during in-flight request with proper finally re-enable. |
| index.html | Corrected display email to .ai domain, added accessible honeypot field, added submitBtn id, cache-busted script tag. |
| wrangler.toml | Updated CONTACT_EMAIL to .ai domain, added SITE_NAME var, cleaned up redundant observability fields; parent [observability] block intentionally removed so logs subsection can be enabled independently. |
| package.json | Added build:public and dev:worker scripts for local end-to-end Worker testing. |
| sass/components/_contact-form.scss | Added .honeypot rule to visually hide the spam-trap field off-screen. |
| dist/css/main.css | Compiled CSS artifact reflecting the new .honeypot rule. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: js/main.js
Line: 158

Comment:
**"Sending" status shown in success (green) colour**

`setStatus('Sending your message...', 'success')` applies `form-status--success` while the request is still in flight, so the user sees a green "Sending…" message. A neutral/informational style would be more accurate here; since there are only two classes today, a quick option is to leave the class list empty until the outcome is known, or add a `form-status--info` variant.

```suggestion
      setStatus('Sending your message...', '');
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(email) resend config"](https://github.com/bytes0211/bytestreams/commit/0653c0ffc38f2b06592e76d722dcc109afb2c0de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29688108)</sub>

<!-- /greptile_comment -->